### PR TITLE
Fix Zombie sh Processes From Web Terminal

### DIFF
--- a/server/service/vm/terminal.go
+++ b/server/service/vm/terminal.go
@@ -119,6 +119,8 @@ func (s *Service) Terminal(c *gin.Context) {
 	defer func() {
 		_ = ptmx.Close()
 		_ = cmd.Process.Kill()
+		// Wait & reap sub-process; needed to prevent zombie processes
+		_ = cmd.Wait()
 	}()
 
 	go wsWrite(ws, ptmx)


### PR DESCRIPTION
See https://github.com/sipeed/NanoKVM-Pro/issues/55

Seems like we launch the `sh` process, wait for the web session to be over, then kill it. However, we don't `Wait()` for the process after that, so the process objects do not get cleaned up properly. See https://linux.die.net/man/2/waitpid for details on why this occurs.

After this change, I can see no more zombie processes get left behind. Not sure if this has performance implications though.