### PR TITLE
fix: enhance mobile phone user experience

### DIFF
--- a/web/src/pages/desktop/mouse/absolute.tsx
+++ b/web/src/pages/desktop/mouse/absolute.tsx
@@ -16,7 +16,7 @@ enum MouseButton {
 }
 
 export const Absolute = () => {
-  const isBigScreen = useMediaQuery({ minWidth: 850 });
+  const isBigScreen = useMediaQuery({ minWidth: 650 });
 
   const scrollInterval = useAtomValue(scrollIntervalAtom);
 

--- a/web/src/pages/desktop/screen/h264-direct.tsx
+++ b/web/src/pages/desktop/screen/h264-direct.tsx
@@ -59,7 +59,7 @@ export const H264Direct = () => {
         id="screen"
         ref={canvasRef}
         className={clsx(
-          'block min-h-[480px] min-w-[640px] max-w-full select-none object-scale-down',
+          'block min-h-[50vh] min-w-[50vw] max-w-full select-none object-scale-down',
           mouseStyle
         )}
         style={{ maxHeight: 'calc(100% - 75px)', transform: `scale(${videoParameters.scale})` }}

--- a/web/src/pages/desktop/screen/h264-webrtc.tsx
+++ b/web/src/pages/desktop/screen/h264-webrtc.tsx
@@ -312,7 +312,7 @@ export const H264Webrtc = () => {
           id="screen"
           ref={videoRef}
           className={clsx(
-            'block max-h-full min-h-[480px] min-w-[640px] max-w-full select-none object-scale-down',
+            'block max-h-full min-h-[50vh] min-w-[50vw] max-w-full select-none object-scale-down',
             isPlaying ? 'opacity-100' : 'opacity-0',
             mouseStyle
           )}

--- a/web/src/pages/desktop/screen/mjpeg.tsx
+++ b/web/src/pages/desktop/screen/mjpeg.tsx
@@ -16,7 +16,7 @@ export const Mjpeg = () => {
       <Image
         id="screen"
         className={clsx(
-          'block max-h-screen min-h-[480px] min-w-[640px] select-none object-scale-down',
+          'block max-h-screen min-h-[50vh] min-w-[50vw] select-none object-scale-down',
           mouseStyle
         )}
         style={{ transform: `scale(${videoParameters.scale})` }}


### PR DESCRIPTION
Based on my testing, the width of the iPhone XR in full-screen mode in Safari is 800px, and the width of the Xiaomi 14 in full-screen mode in Chrome is 845px. The current configuration ignores touch events on these models.

Also, because these devices use a minimum width of 640x480 for web pages by default, scaling issues may occur.
