### PR TITLE
add support for http protocol

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -74,10 +74,16 @@ func run() {
 	httpAddr := fmt.Sprintf(":%d", conf.Port.Http)
 	httpsAddr := fmt.Sprintf(":%d", conf.Port.Https)
 
-	go runRedirect(httpAddr, httpsAddr)
-
-	if err := r.RunTLS(httpsAddr, conf.Cert.Crt, conf.Cert.Key); err != nil {
-		log.Fatalf("start https server failed: %v", err)
+	if conf.Proto == "https" {
+		go runRedirect(httpAddr, httpsAddr)
+		
+		if err := r.RunTLS(httpsAddr, conf.Cert.Crt, conf.Cert.Key); err != nil {
+			log.Fatalf("start https server failed: %v", err)
+		}
+	} else {
+		if err := r.Run(httpAddr); err != nil {
+			panic("start http server failed")
+		}
 	}
 }
 


### PR DESCRIPTION
This PR adds support for the "http" protocol mode in the configuration file, which results in serving the site on the HTTP port without a redirect. Prior to this PR, the protocol configuration option does not appear to do anything and the site is always served on the HTTPS port with a HTTP -> HTTPS redirect.

The configuration file already defaults to "https" as the protocol, so this should not be a breaking change for existing users.

The code in this PR has been backported from the non-PRO NanoKVM: https://github.com/sipeed/NanoKVM/blob/main/server/main.go

This is actively blocking my ability to use the NanoKVM Pro in my network environment, I would appreciate if this could be merged as soon as possible.