### PR TITLE
feat: highlight Images icon when image is mounted

### DIFF
--- a/web/src/pages/desktop/menu/image/index.tsx
+++ b/web/src/pages/desktop/menu/image/index.tsx
@@ -1,6 +1,9 @@
+import { useEffect, useState } from 'react';
+import clsx from 'clsx';
 import { DiscIcon } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
+import * as api from '@/api/storage.ts';
 import { MenuItem } from '@/components/menu-item';
 
 import { DownloadImage } from './downloadImage';
@@ -9,10 +12,30 @@ import { UploaderImages } from './uploader-images';
 
 export const Image = () => {
   const { t } = useTranslation();
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    api.getMountedImage().then((rsp) => {
+      if (rsp.code === 0) {
+        setIsMounted(!!rsp.data?.file);
+      }
+    });
+  }, []);
+
+  const icon = (
+    <div
+      className={clsx(
+        'h-[18px] w-[18px]',
+        isMounted ? 'text-blue-500' : 'text-neutral-300 hover:text-white'
+      )}
+    >
+      <DiscIcon size={18} />
+    </div>
+  );
 
   const content = (
     <div className="flex flex-col space-y-1">
-      <MounteImage />
+      <MounteImage isMounted={isMounted} setIsMounted={setIsMounted} />
       <UploaderImages />
       <DownloadImage />
     </div>
@@ -21,7 +44,7 @@ export const Image = () => {
   return (
     <MenuItem
       title={t('image.title')}
-      icon={<DiscIcon size={18} />}
+      icon={icon}
       content={content}
       fresh={true}
     />

--- a/web/src/pages/desktop/menu/image/mounteImage.tsx
+++ b/web/src/pages/desktop/menu/image/mounteImage.tsx
@@ -9,11 +9,15 @@ import { getVirtualDevice, refreshVirtualDevice } from '@/api/virtual-device.ts'
 
 import { Images } from './images';
 
-export function MounteImage() {
+type MounteImageProps = {
+  isMounted: boolean;
+  setIsMounted: (isMounted: boolean) => void;
+};
+
+export function MounteImage({ isMounted, setIsMounted }: MounteImageProps) {
   const { t } = useTranslation();
 
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [isMounted, setIsMounted] = useState(false);
   const [mode, setMode] = useState('mass-storage');
   const [readOnly, setReadOnly] = useState(true);
 
@@ -53,11 +57,13 @@ export function MounteImage() {
       return;
     }
 
-    if (!rsp?.data?.file) {
+    const file = rsp.data?.file;
+    setIsMounted(!!file);
+
+    if (!file) {
       return;
     }
 
-    setIsMounted(true);
     setMode(rsp.data?.cdrom ? 'cd-rom' : 'mass-storage');
     setReadOnly(!!rsp.data?.readOnly);
   }


### PR DESCRIPTION
## Summary

This PR addresses #95, where the top-level Images icon does not indicate whether an image is currently mounted. Users have to open the Images menu and check the "Mount Image" entry to see the current state.

The implementation follows the existing non-Pro NanoKVM UI: the Images icon turns blue while an image is mounted and returns to its normal color after the image is unmounted.

## Changes

- Moved the mounted state to the top-level `Image` component so it can control the icon color.
- Reused the existing `MounteImage -> Images` state update path for mount and unmount operations.
- Explicitly clears the mounted state when the API returns an empty image path.
- No backend or API changes.

## Verification

- `pnpm build`
- `pnpm lint` (0 errors; existing warnings remain)

## Screenshot

<img width="452" height="165" alt="image" src="https://github.com/user-attachments/assets/404f770e-4c5b-41f1-9fde-180e553ac80e" />

Closes #95