### PR TITLE
feat: support video rotation

### DIFF
--- a/web/src/i18n/locales/cz.ts
+++ b/web/src/i18n/locales/cz.ts
@@ -44,6 +44,7 @@ const cz = {
       qualityHigh: 'Vysoký',
       qualityMedium: 'Střední',
       qualityLow: 'Nízký',
+      rotation: 'Otočení',
       resetHdmi: 'Reset HDMI'
     },
     keyboard: {

--- a/web/src/i18n/locales/da.ts
+++ b/web/src/i18n/locales/da.ts
@@ -43,6 +43,7 @@ const da = {
       qualityHigh: 'Høj',
       qualityMedium: 'Mellem',
       qualityLow: 'Lav',
+      rotation: 'Rotation',
       resetHdmi: 'Reset HDMI'
     },
     keyboard: {

--- a/web/src/i18n/locales/de.ts
+++ b/web/src/i18n/locales/de.ts
@@ -45,6 +45,7 @@ const de = {
       qualityHigh: 'Hoch',
       qualityMedium: 'Mittel',
       qualityLow: 'Niedrig',
+      rotation: 'Drehung',
       resetHdmi: 'HDMI zurücksetzen'
     },
     keyboard: {

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -93,6 +93,7 @@ const en = {
       qualityMedium: 'Medium',
       qualityLow: 'Low',
       scale: 'Scale',
+      rotation: 'Rotation',
       resetHdmi: 'Reset HDMI',
       noSignal: 'HDMI no signal',
       inconsistentVideoMode: 'Play paused. Another video mode is playing.',

--- a/web/src/i18n/locales/es.ts
+++ b/web/src/i18n/locales/es.ts
@@ -44,6 +44,7 @@ const en = {
       qualityHigh: 'Alto',
       qualityMedium: 'Medio',
       qualityLow: 'Bajo',
+      rotation: 'Rotación',
       resetHdmi: 'Reset HDMI'
     },
     keyboard: {

--- a/web/src/i18n/locales/fr.ts
+++ b/web/src/i18n/locales/fr.ts
@@ -45,6 +45,7 @@ const fr = {
       qualityHigh: 'Élevé',
       qualityMedium: 'Moyen',
       qualityLow: 'Bas',
+      rotation: 'Rotation',
       resetHdmi: 'Réinitialiser le HDMI'
     },
     keyboard: {

--- a/web/src/i18n/locales/hu.ts
+++ b/web/src/i18n/locales/hu.ts
@@ -44,6 +44,7 @@ const hu = {
       qualityHigh: 'Magas',
       qualityMedium: 'Közepes',
       qualityLow: 'Alacsony',
+      rotation: 'Forgatás',
       resetHdmi: 'Reset HDMI'
     },
     keyboard: {

--- a/web/src/i18n/locales/id.ts
+++ b/web/src/i18n/locales/id.ts
@@ -53,6 +53,7 @@ const id = {
       qualityHigh: 'Tinggi',
       qualityMedium: 'Sedang',
       qualityLow: 'Rendah',
+      rotation: 'Rotasi',
       resetHdmi: 'Reset HDMI'
     },
     keyboard: {

--- a/web/src/i18n/locales/it.ts
+++ b/web/src/i18n/locales/it.ts
@@ -44,6 +44,7 @@ const it = {
       qualityHigh: 'Alto',
       qualityMedium: 'Medio',
       qualityLow: 'Basso',
+      rotation: 'Rotazione',
       resetHdmi: 'Reset HDMI'
     },
     keyboard: {

--- a/web/src/i18n/locales/ja.ts
+++ b/web/src/i18n/locales/ja.ts
@@ -44,6 +44,7 @@ const ja = {
       qualityHigh: '高い',
       qualityMedium: '中くらい',
       qualityLow: '低い',
+      rotation: '回転',
       resetHdmi: 'Reset HDMI'
     },
     keyboard: {

--- a/web/src/i18n/locales/ko.ts
+++ b/web/src/i18n/locales/ko.ts
@@ -43,6 +43,7 @@ const ko = {
       qualityHigh: '높음',
       qualityMedium: '중간',
       qualityLow: '낮음',
+      rotation: '회전',
       resetHdmi: 'HDMI 초기화'
     },
     keyboard: {

--- a/web/src/i18n/locales/nb.ts
+++ b/web/src/i18n/locales/nb.ts
@@ -44,6 +44,7 @@ const nb = {
       qualityHigh: 'Høy',
       qualityMedium: 'Medium',
       qualityLow: 'Lav',
+      rotation: 'Rotasjon',
       resetHdmi: 'Reset HDMI'
     },
     keyboard: {

--- a/web/src/i18n/locales/nl.ts
+++ b/web/src/i18n/locales/nl.ts
@@ -44,6 +44,7 @@ const nl = {
       qualityHigh: 'Hoog',
       qualityMedium: 'Gemiddeld',
       qualityLow: 'Laag',
+      rotation: 'Rotatie',
       resetHdmi: 'Reset HDMI'
     },
     keyboard: {

--- a/web/src/i18n/locales/pl.ts
+++ b/web/src/i18n/locales/pl.ts
@@ -36,6 +36,7 @@ const pl = {
       qualityHigh: 'Wysoki',
       qualityMedium: 'Średni',
       qualityLow: 'Niski',
+      rotation: 'Obrót',
       resetHdmi: 'Reset HDMI'
     },
     keyboard: {

--- a/web/src/i18n/locales/ru.ts
+++ b/web/src/i18n/locales/ru.ts
@@ -87,6 +87,7 @@ const ru = {
       qualityMedium: 'Средний',
       qualityLow: 'Низкий',
       scale: 'Масштаб',
+      rotation: 'Поворот',
       resetHdmi: 'Перезагрузить HDMI подсистему',
       noSignal: 'Нет сигнала HDMI',
       inconsistentVideoMode:

--- a/web/src/i18n/locales/th.ts
+++ b/web/src/i18n/locales/th.ts
@@ -42,6 +42,7 @@ const th = {
       qualityHigh: 'สูง',
       qualityMedium: 'กลาง',
       qualityLow: 'ต่ำ',
+      rotation: 'การหมุน',
       resetHdmi: 'รีเช็ท HDMI'
     },
     keyboard: {

--- a/web/src/i18n/locales/uk.ts
+++ b/web/src/i18n/locales/uk.ts
@@ -45,6 +45,7 @@ const uk = {
       qualityHigh: 'Високий',
       qualityMedium: 'Середній',
       qualityLow: 'Низький',
+      rotation: 'Обертання',
       resetHdmi: 'Перезавантажити HDMI підсистему'
     },
     keyboard: {

--- a/web/src/i18n/locales/vi.ts
+++ b/web/src/i18n/locales/vi.ts
@@ -43,6 +43,7 @@ const vi = {
       qualityHigh: 'Cao',
       qualityMedium: 'Trung bình',
       qualityLow: 'Thấp',
+      rotation: 'Xoay',
       resetHdmi: 'Reset HDMI'
     },
     keyboard: {

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -79,6 +79,7 @@ const zh = {
       qualityMedium: '中',
       qualityLow: '低',
       scale: '缩放',
+      rotation: '旋转',
       resetHdmi: '重置 HDMI',
       noSignal: 'HDMI 无信号',
       inconsistentVideoMode: '已暂停，其他视频模式正在播放中',

--- a/web/src/i18n/locales/zh_tw.ts
+++ b/web/src/i18n/locales/zh_tw.ts
@@ -42,6 +42,7 @@ const zh_tw = {
       qualityHigh: '高',
       qualityMedium: '中',
       qualityLow: '低',
+      rotation: '旋轉',
       resetHdmi: '重置 HDMI'
     },
     keyboard: {

--- a/web/src/jotai/screen.ts
+++ b/web/src/jotai/screen.ts
@@ -10,6 +10,7 @@ export const videoParametersAtom = atom<VideoParameters>({
   gop: 50, // 1 - 200
   fps: 0, // 0 - 120
   scale: 1,
+  rotation: 0,
   quality: 80 // 1-100 (only for mjpeg)
 });
 

--- a/web/src/lib/video-transform.ts
+++ b/web/src/lib/video-transform.ts
@@ -11,16 +11,28 @@ export function getScreenElement() {
   return screen?.querySelector('img') ?? screen;
 }
 
-export function getVideoTransformStyle(scale: number, rotation: VideoRotation): CSSProperties {
+export function getVideoRotationStyle(scale: number, rotation: VideoRotation): CSSProperties {
+  return {
+    transform: `scale(${scale}) rotate(${rotation}deg)`,
+    transformOrigin: 'center'
+  };
+}
+
+export function getVideoSizeStyle(rotation: VideoRotation): CSSProperties {
   const quarterTurn = isQuarterTurn(rotation);
 
   return {
-    transform: `scale(${scale}) rotate(${rotation}deg)`,
-    transformOrigin: 'center',
     minWidth: quarterTurn ? 'min(50vw, 100vh)' : undefined,
     minHeight: quarterTurn ? 'min(50vh, 100vw)' : undefined,
     maxWidth: quarterTurn ? '100vh' : '100vw',
     maxHeight: quarterTurn ? '100vw' : '100vh'
+  };
+}
+
+export function getVideoTransformStyle(scale: number, rotation: VideoRotation): CSSProperties {
+  return {
+    ...getVideoRotationStyle(scale, rotation),
+    ...getVideoSizeStyle(rotation)
   };
 }
 

--- a/web/src/lib/video-transform.ts
+++ b/web/src/lib/video-transform.ts
@@ -1,0 +1,51 @@
+import type { CSSProperties } from 'react';
+
+import { VideoRotation } from '@/types';
+
+export function isQuarterTurn(rotation: VideoRotation) {
+  return rotation === 90 || rotation === 270;
+}
+
+export function getScreenElement() {
+  const screen = document.getElementById('screen');
+  return screen?.querySelector('img') ?? screen;
+}
+
+export function getVideoTransformStyle(scale: number, rotation: VideoRotation): CSSProperties {
+  const quarterTurn = isQuarterTurn(rotation);
+
+  return {
+    transform: `scale(${scale}) rotate(${rotation}deg)`,
+    transformOrigin: 'center',
+    minWidth: quarterTurn ? 'min(50vw, 100vh)' : undefined,
+    minHeight: quarterTurn ? 'min(50vh, 100vw)' : undefined,
+    maxWidth: quarterTurn ? '100vh' : '100vw',
+    maxHeight: quarterTurn ? '100vw' : '100vh'
+  };
+}
+
+export function inverseRotatePoint(x: number, y: number, rotation: VideoRotation) {
+  switch (rotation) {
+    case 90:
+      return { x: y, y: 1 - x };
+    case 180:
+      return { x: 1 - x, y: 1 - y };
+    case 270:
+      return { x: 1 - y, y: x };
+    default:
+      return { x, y };
+  }
+}
+
+export function inverseRotateDelta(x: number, y: number, rotation: VideoRotation) {
+  switch (rotation) {
+    case 90:
+      return { x: y, y: -x };
+    case 180:
+      return { x: -x, y: -y };
+    case 270:
+      return { x: -y, y: x };
+    default:
+      return { x, y };
+  }
+}

--- a/web/src/pages/desktop/menu/screen/index.tsx
+++ b/web/src/pages/desktop/menu/screen/index.tsx
@@ -13,6 +13,7 @@ import { Advanced } from './advanced.tsx';
 import { Bitrate } from './bitrate.tsx';
 import { Edid } from './edid.tsx';
 import { Quality } from './quality';
+import { Rotation } from './rotation.tsx';
 import { Scale } from './scale.tsx';
 import { VideoMode } from './video-mode.tsx';
 
@@ -31,7 +32,11 @@ export const Screen = () => {
 
   async function initScreen() {
     const parameters = getVideoParameters();
-    let { rateControlMode, bitrate, gop, fps, scale, quality } = parameters;
+    let { rateControlMode, bitrate, gop, fps, quality } = parameters;
+
+    const scale = getScale(parameters.scale);
+    const rotation = getRotation(parameters.rotation);
+    setVideoParameters({ ...parameters, scale, rotation });
 
     try {
       if (videoMode === 'mjpeg') {
@@ -43,16 +48,15 @@ export const Screen = () => {
       }
 
       fps = await updateFps(parameters.fps);
-      scale = getScale(parameters.scale);
 
-      setVideoParameters({
+      setVideoParameters((current) => ({
+        ...current,
         rateControlMode,
         bitrate,
         gop,
         fps,
-        scale,
         quality
-      });
+      }));
     } catch (err) {
       console.log(err);
     }
@@ -138,12 +142,20 @@ export const Screen = () => {
     return scale;
   }
 
+  function getRotation(rotation: VideoParameters['rotation']) {
+    if (![0, 90, 180, 270].includes(rotation)) {
+      return 0;
+    }
+    return rotation;
+  }
+
   const content = (
     <div className="flex flex-col space-y-1">
       <VideoMode />
       <Edid />
       {videoMode === 'mjpeg' ? <Quality /> : <Bitrate />}
       <Scale />
+      <Rotation />
       <Advanced />
     </div>
   );

--- a/web/src/pages/desktop/menu/screen/rotation.tsx
+++ b/web/src/pages/desktop/menu/screen/rotation.tsx
@@ -1,0 +1,50 @@
+import { ReactElement } from 'react';
+import { Popover } from 'antd';
+import { useAtom } from 'jotai';
+import { CheckIcon, RotateCwIcon } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { VideoRotation } from '@/types';
+import * as storage from '@/lib/localstorage.ts';
+import { videoParametersAtom } from '@/jotai/screen.ts';
+
+const RotationList: VideoRotation[] = [0, 90, 180, 270];
+
+export const Rotation = (): ReactElement => {
+  const { t } = useTranslation();
+  const [videoParameters, setVideoParameters] = useAtom(videoParametersAtom);
+
+  function update(rotation: VideoRotation) {
+    const parameters = { ...videoParameters, rotation };
+    setVideoParameters(parameters);
+    storage.setVideoParameters(JSON.stringify(parameters));
+  }
+
+  const content = (
+    <>
+      {RotationList.map((rotation) => (
+        <div
+          key={rotation}
+          className="flex h-[30px] cursor-pointer select-none items-center rounded pl-1 pr-5 hover:bg-neutral-700/70"
+          onClick={() => update(rotation)}
+        >
+          <div className="flex h-[14px] w-[20px] items-end text-blue-500">
+            {rotation === videoParameters.rotation && <CheckIcon size={14} />}
+          </div>
+          <span>{rotation}&deg;</span>
+        </div>
+      ))}
+    </>
+  );
+
+  return (
+    <Popover content={content} placement="rightTop" arrow={false} align={{ offset: [13, 0] }}>
+      <div className="flex h-[30px] cursor-pointer items-center space-x-1 rounded pl-3 pr-6 text-neutral-300 hover:bg-neutral-700/50">
+        <div className="flex h-[14px] w-[20px] items-end">
+          <RotateCwIcon size={16} />
+        </div>
+        <span>{t('screen.rotation')}</span>
+      </div>
+    </Popover>
+  );
+};

--- a/web/src/pages/desktop/mouse/absolute.tsx
+++ b/web/src/pages/desktop/mouse/absolute.tsx
@@ -3,8 +3,10 @@ import { useAtomValue } from 'jotai';
 import { useMediaQuery } from 'react-responsive';
 
 import { MouseReportAbsolute } from '@/lib/mouse.ts';
+import { getScreenElement, inverseRotatePoint, isQuarterTurn } from '@/lib/video-transform.ts';
 import { client, MessageEvent } from '@/lib/websocket.ts';
 import { scrollDirectionAtom, scrollIntervalAtom } from '@/jotai/mouse.ts';
+import { videoModeAtom, videoParametersAtom } from '@/jotai/screen.ts';
 
 import { MouseAbsoluteEvent } from './types.ts';
 
@@ -21,6 +23,8 @@ export const Absolute = () => {
 
   const scrollDirection = useAtomValue(scrollDirectionAtom);
   const scrollInterval = useAtomValue(scrollIntervalAtom);
+  const videoMode = useAtomValue(videoModeAtom);
+  const videoParameters = useAtomValue(videoParametersAtom);
 
   const mouseRef = useRef(new MouseReportAbsolute());
   const lastPosRef = useRef({ x: 0.5, y: 0.5 });
@@ -41,8 +45,9 @@ export const Absolute = () => {
   const VELOCITY_THRESHOLD = 0.3;
 
   useEffect(() => {
-    const screen = document.getElementById('screen') as HTMLVideoElement;
-    if (!screen) return;
+    const screenElement = getScreenElement();
+    if (!screenElement) return;
+    const screen = screenElement;
 
     screen.addEventListener('mousedown', handleMouseDown);
     screen.addEventListener('mouseup', handleMouseUp);
@@ -256,14 +261,18 @@ export const Absolute = () => {
 
     function getCorrectedCoords(clientX: number, clientY: number) {
       const rect = screen.getBoundingClientRect();
+      const mediaSize = getMediaSize(screen);
 
-      if (!screen.videoWidth || !screen.videoHeight) {
+      if (!mediaSize) {
         const x = (clientX - rect.left) / rect.width;
         const y = (clientY - rect.top) / rect.height;
-        return { x, y };
+        return inverseRotatePoint(x, y, videoParameters.rotation);
       }
 
-      const videoRatio = screen.videoWidth / screen.videoHeight;
+      const rotatedMediaSize = isQuarterTurn(videoParameters.rotation)
+        ? { width: mediaSize.height, height: mediaSize.width }
+        : mediaSize;
+      const videoRatio = rotatedMediaSize.width / rotatedMediaSize.height;
       const elementRatio = rect.width / rect.height;
 
       let renderedWidth = rect.width;
@@ -282,7 +291,7 @@ export const Absolute = () => {
       const x = (clientX - rect.left - offsetX) / renderedWidth;
       const y = (clientY - rect.top - offsetY) / renderedHeight;
 
-      return { x, y };
+      return inverseRotatePoint(x, y, videoParameters.rotation);
     }
 
     return () => {
@@ -301,7 +310,7 @@ export const Absolute = () => {
         clearTimeout(longPressTimerRef.current);
       }
     };
-  }, [isBigScreen, scrollDirection, scrollInterval]);
+  }, [isBigScreen, scrollDirection, scrollInterval, videoMode, videoParameters.rotation]);
 
   // Mouse event handler
   function handleMouseEvent(event: MouseAbsoluteEvent) {
@@ -345,3 +354,19 @@ export const Absolute = () => {
 
   return <></>;
 };
+
+function getMediaSize(screen: Element) {
+  if (screen instanceof HTMLVideoElement && screen.videoWidth > 0 && screen.videoHeight > 0) {
+    return { width: screen.videoWidth, height: screen.videoHeight };
+  }
+
+  if (screen instanceof HTMLImageElement && screen.naturalWidth > 0 && screen.naturalHeight > 0) {
+    return { width: screen.naturalWidth, height: screen.naturalHeight };
+  }
+
+  if (screen instanceof HTMLCanvasElement && screen.width > 0 && screen.height > 0) {
+    return { width: screen.width, height: screen.height };
+  }
+
+  return null;
+}

--- a/web/src/pages/desktop/mouse/relative.tsx
+++ b/web/src/pages/desktop/mouse/relative.tsx
@@ -4,8 +4,10 @@ import { useAtomValue } from 'jotai';
 import { useTranslation } from 'react-i18next';
 
 import { MouseReportRelative } from '@/lib/mouse.ts';
+import { getScreenElement, inverseRotateDelta } from '@/lib/video-transform.ts';
 import { client, MessageEvent } from '@/lib/websocket.ts';
 import { scrollDirectionAtom, scrollIntervalAtom } from '@/jotai/mouse.ts';
+import { videoModeAtom, videoParametersAtom } from '@/jotai/screen.ts';
 
 import { MouseRelativeEvent } from './types.ts';
 
@@ -15,6 +17,8 @@ export const Relative = () => {
 
   const scrollDirection = useAtomValue(scrollDirectionAtom);
   const scrollInterval = useAtomValue(scrollIntervalAtom);
+  const videoMode = useAtomValue(videoModeAtom);
+  const videoParameters = useAtomValue(videoParametersAtom);
 
   const mouseRef = useRef(new MouseReportRelative());
   const isLockedRef = useRef(false);
@@ -50,7 +54,7 @@ export const Relative = () => {
   }
 
   useEffect(() => {
-    const screen = document.getElementById('screen');
+    const screen = getScreenElement();
     if (!screen) return;
 
     showMessage();
@@ -60,8 +64,12 @@ export const Relative = () => {
     screen.addEventListener('mouseup', handleMouseUp);
     screen.addEventListener('mousemove', handleMouseMove);
     screen.addEventListener('wheel', handleMouseWheel, { passive: false });
-    screen.addEventListener('contextmenu', (e) => e.preventDefault());
+    screen.addEventListener('contextmenu', handleContextMenu);
     document.addEventListener('pointerlockchange', handlePointerLockChange);
+
+    function handleContextMenu(event: Event) {
+      event.preventDefault();
+    }
 
     // Mouse click event
     function handleMouseClick(event: MouseEvent) {
@@ -94,8 +102,9 @@ export const Relative = () => {
 
       const deltaX = Math.abs(x * window.devicePixelRatio) < 10 ? x * 2 : x;
       const deltaY = Math.abs(y * window.devicePixelRatio) < 10 ? y * 2 : y;
+      const delta = inverseRotateDelta(deltaX, deltaY, videoParameters.rotation);
 
-      handleMouseEvent({ type: 'move', deltaX, deltaY });
+      handleMouseEvent({ type: 'move', deltaX: delta.x, deltaY: delta.y });
     }
 
     // Mouse wheel event
@@ -126,10 +135,10 @@ export const Relative = () => {
       screen.removeEventListener('mousedown', handleMouseDown);
       screen.removeEventListener('mouseup', handleMouseUp);
       screen.removeEventListener('wheel', handleMouseWheel);
-      screen.removeEventListener('contextmenu', disableEvent);
+      screen.removeEventListener('contextmenu', handleContextMenu);
       document.removeEventListener('pointerlockchange', handlePointerLockChange);
     };
-  }, [scrollDirection, scrollInterval]);
+  }, [scrollDirection, scrollInterval, videoMode, videoParameters.rotation]);
 
   // show message
   function showMessage() {

--- a/web/src/pages/desktop/screen/h264-direct.tsx
+++ b/web/src/pages/desktop/screen/h264-direct.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import { useAtomValue } from 'jotai';
 
 import * as api from '@/api/stream.ts';
+import { getVideoTransformStyle, isQuarterTurn } from '@/lib/video-transform.ts';
 import { mouseStyleAtom } from '@/jotai/mouse';
 import { videoParametersAtom } from '@/jotai/screen.ts';
 
@@ -54,15 +55,20 @@ export const H264Direct = () => {
   }, []);
 
   return (
-    <div className="flex h-screen w-screen items-start justify-center xl:items-center">
+    <div
+      className={clsx(
+        'flex h-screen w-screen justify-center',
+        isQuarterTurn(videoParameters.rotation) ? 'items-center' : 'items-start xl:items-center'
+      )}
+    >
       <canvas
         id="screen"
         ref={canvasRef}
         className={clsx(
-          'block min-h-[50vh] min-w-[50vw] max-w-full select-none object-scale-down',
+          'block min-h-[50vh] min-w-[50vw] max-w-full select-none object-contain',
           mouseStyle
         )}
-        style={{ transform: `scale(${videoParameters.scale})` }}
+        style={getVideoTransformStyle(videoParameters.scale, videoParameters.rotation)}
       ></canvas>
     </div>
   );

--- a/web/src/pages/desktop/screen/h264-webrtc.tsx
+++ b/web/src/pages/desktop/screen/h264-webrtc.tsx
@@ -5,6 +5,7 @@ import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 
 import * as api from '@/api/stream.ts';
 import { VideoStatus } from '@/types';
+import { getVideoTransformStyle, isQuarterTurn } from '@/lib/video-transform.ts';
 import { microphoneEnabledAtom } from '@/jotai/audio.ts';
 import { mouseStyleAtom } from '@/jotai/mouse.ts';
 import { videoParametersAtom, videoStatusAtom, videoVolumeAtom } from '@/jotai/screen.ts';
@@ -368,16 +369,21 @@ export const H264Webrtc = () => {
 
   return (
     <Spin size="large" tip="Loading" spinning={isLoading}>
-      <div className="flex h-screen w-screen items-start justify-center xl:items-center">
+      <div
+        className={clsx(
+          'flex h-screen w-screen justify-center',
+          isQuarterTurn(videoParameters.rotation) ? 'items-center' : 'items-start xl:items-center'
+        )}
+      >
         <video
           id="screen"
           ref={videoRef}
           className={clsx(
-            'block max-h-full min-h-[50vh] min-w-[50vw] max-w-full select-none object-scale-down',
+            'block max-h-full min-h-[50vh] min-w-[50vw] max-w-full select-none object-contain',
             isPlaying ? 'opacity-100' : 'opacity-0',
             mouseStyle
           )}
-          style={{ transform: `scale(${videoParameters.scale})` }}
+          style={getVideoTransformStyle(videoParameters.scale, videoParameters.rotation)}
           muted
           autoPlay
           playsInline

--- a/web/src/pages/desktop/screen/h264-webrtc.tsx
+++ b/web/src/pages/desktop/screen/h264-webrtc.tsx
@@ -5,7 +5,7 @@ import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 
 import * as api from '@/api/stream.ts';
 import { VideoStatus } from '@/types';
-import { getVideoTransformStyle, isQuarterTurn } from '@/lib/video-transform.ts';
+import { getVideoRotationStyle, getVideoSizeStyle, isQuarterTurn } from '@/lib/video-transform.ts';
 import { microphoneEnabledAtom } from '@/jotai/audio.ts';
 import { mouseStyleAtom } from '@/jotai/mouse.ts';
 import { videoParametersAtom, videoStatusAtom, videoVolumeAtom } from '@/jotai/screen.ts';
@@ -375,25 +375,31 @@ export const H264Webrtc = () => {
           isQuarterTurn(videoParameters.rotation) ? 'items-center' : 'items-start xl:items-center'
         )}
       >
-        <video
-          id="screen"
-          ref={videoRef}
-          className={clsx(
-            'block max-h-full min-h-[50vh] min-w-[50vw] max-w-full select-none object-contain',
-            isPlaying ? 'opacity-100' : 'opacity-0',
-            mouseStyle
-          )}
-          style={getVideoTransformStyle(videoParameters.scale, videoParameters.rotation)}
-          muted
-          autoPlay
-          playsInline
-          controls={false}
-          onPlaying={() => setIsLoading(false)}
-          onClick={(e) => {
-            e.stopPropagation();
-            e.preventDefault();
-          }}
-        />
+        {/* Keep transforms off the hardware-decoded video layer to avoid blank quarter turns. */}
+        <div
+          className="flex"
+          style={getVideoRotationStyle(videoParameters.scale, videoParameters.rotation)}
+        >
+          <video
+            id="screen"
+            ref={videoRef}
+            className={clsx(
+              'block max-h-full min-h-[50vh] min-w-[50vw] max-w-full select-none object-contain',
+              isPlaying ? 'opacity-100' : 'opacity-0',
+              mouseStyle
+            )}
+            style={getVideoSizeStyle(videoParameters.rotation)}
+            muted
+            autoPlay
+            playsInline
+            controls={false}
+            onPlaying={() => setIsLoading(false)}
+            onClick={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+            }}
+          />
+        </div>
 
         <audio ref={audioRef} muted autoPlay playsInline />
       </div>

--- a/web/src/pages/desktop/screen/mjpeg.tsx
+++ b/web/src/pages/desktop/screen/mjpeg.tsx
@@ -4,6 +4,7 @@ import { useAtomValue } from 'jotai';
 
 import MonitorXIcon from '@/assets/images/monitor-x.svg';
 import { getBaseUrl } from '@/lib/service.ts';
+import { getVideoTransformStyle, isQuarterTurn } from '@/lib/video-transform.ts';
 import { mouseStyleAtom } from '@/jotai/mouse.ts';
 import { videoParametersAtom } from '@/jotai/screen.ts';
 
@@ -12,14 +13,19 @@ export const Mjpeg = () => {
   const mouseStyle = useAtomValue(mouseStyleAtom);
 
   return (
-    <div className="flex h-screen w-screen items-start justify-center xl:items-center">
+    <div
+      className={clsx(
+        'flex h-screen w-screen justify-center',
+        isQuarterTurn(videoParameters.rotation) ? 'items-center' : 'items-start xl:items-center'
+      )}
+    >
       <Image
         id="screen"
         className={clsx(
-          'block max-h-screen min-h-[50vh] min-w-[50vw] select-none object-scale-down',
+          'block max-h-screen min-h-[50vh] min-w-[50vw] select-none object-contain',
           mouseStyle
         )}
-        style={{ transform: `scale(${videoParameters.scale})` }}
+        style={getVideoTransformStyle(videoParameters.scale, videoParameters.rotation)}
         src={`${getBaseUrl('http')}/api/stream/mjpeg`}
         fallback={MonitorXIcon}
         preview={false}

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -1,11 +1,14 @@
 export type VideoMode = 'h265-webrtc' | 'h265-direct' | 'h264-webrtc' | 'h264-direct' | 'mjpeg';
 
+export type VideoRotation = 0 | 90 | 180 | 270;
+
 export interface VideoParameters {
   rateControlMode: string; // cbr | vbr;
   bitrate: number;
   gop: number;
   fps: number;
   scale: number;
+  rotation: VideoRotation;
   quality?: number; // MJEPG only
 }
 


### PR DESCRIPTION
## Summary

This PR addresses #101 by adding client-side display rotation support to NanoKVM-Pro. The new Rotation entry is placed in the Screen menu between Scale and Advanced Settings and provides 0°, 90°, 180°, and 270° options.

The rotation is applied consistently across MJPEG, H264 WebRTC, and H264 Direct modes. Mouse input is transformed back into the remote display coordinate system so absolute clicks, touch input, and relative pointer movement continue to follow the visible image.

As part of keeping the rendered content bounds consistent with absolute mouse coordinate mapping, all three renderers now use `object-contain`. On large desktop viewports, low-resolution streams may therefore be enlarged to the renderer's media box instead of remaining at native size. This improves pointer accuracy, although interpolated low-resolution content may appear softer.

## Changes

- Added a persisted rotation parameter and a Screen menu selector for 0°, 90°, 180°, and 270°.
- Added shared video transform helpers used by all three video rendering paths.
- Applies WebRTC rotation to a normal wrapper instead of directly transforming the hardware-decoded `<video>` layer, avoiding blank 90° and 270° output on affected clients.
- Adjusted rotated sizing constraints to prevent 90° and 270° layouts from overflowing narrow landscape or portrait viewports.
- Added inverse rotation mapping for absolute pointer coordinates and relative pointer movement.
- Switched all video renderers to `object-contain`, aligning low-resolution rendered content with the content rectangle used by absolute mouse coordinate calculations.
- Preserved the latest client-side scale and rotation values while asynchronous stream settings are initialized.
- Added the Rotation label to all existing frontend locales.
- No backend or API changes.

## Verification

- `pnpm build`
- `pnpm lint` (0 errors; existing warnings remain)
- Verified the menu placement, rotation options, persistence, and legacy local storage fallback with Playwright.
- Injected a local 640×480 MediaStream into the WebRTC renderer and verified playback and geometry at 0°, 90°, and 270°.
- Verified 90° layouts at 844×390 and 390×844 without viewport overflow.
- Verified low-resolution sizing behavior: a 640×480 source is enlarged when the renderer's minimum media box exceeds its intrinsic size, while smaller viewports continue to downscale it normally.
- Verified the enlarged `object-contain` content rectangle has no internal native-size padding that would offset absolute mouse coordinates.
- Performed real-device testing of H264 Direct, H264 WebRTC, and MJPEG against a Windows target. In every mode, all four rotation angles were tested for visual output, relative mouse movement, and absolute pointer accuracy using Microsoft Edge for Android; additional scale checks also passed.
- Verified changing rotation while stream initialization is blocked preserves the persisted bitrate, GOP, FPS, scale, and quality values.

## Screenshots

<img width="613" height="383" alt="image" src="https://github.com/user-attachments/assets/bf83b32f-f6d6-4f90-9d33-e7f6d18bfeb9" />

Closes #101
