### PR TITLE
fix: prevent duplicate React roots in mocked mode

### DIFF
--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -48,9 +48,7 @@ const renderApp = () => {
 
 if (import.meta.env.MODE === 'mocked') {
   const { worker } = await import('./mocks/browser');
-  worker.start().then(() => {
-    return renderApp();
-  });
+  await worker.start();
 }
 
 renderApp();


### PR DESCRIPTION
## Summary

This PR addresses #134, where the mocked Web frontend creates two React roots for the same `#root` container. The first render currently happens before the MSW worker is ready, and a second render happens after `worker.start()` resolves. This can produce duplicate login content, a React duplicate-root warning, and initialization effects that are not cleaned up with the first root.

The mocked startup path now waits for MSW to finish starting before the shared application render. Normal development and production startup continue to render without loading or waiting for MSW.

If `worker.start()` fails in mocked mode, startup fails before `renderApp()` is called; the application is not rendered through an unmocked fallback path. This keeps mocked mode from starting with requests that can escape the mock layer.

## Changes

- Changed the mocked startup path in `web/src/main.tsx` to await `worker.start()` before rendering the application.
- Kept a single shared `renderApp()` call for mocked and non-mocked modes, so `ReactDOM.createRoot()` is called once for the application container.
- In mocked mode, a rejected `worker.start()` now prevents `renderApp()` from running instead of rendering the application before MSW is ready.
- No backend or API changes.

## Verification

- `pnpm exec tsc --noEmit`
- `pnpm build`
- `pnpm lint` (0 errors; 30 unrelated warnings remain)
- `git diff --check`
- Verified `pnpm mocked` with Playwright: one root, one login form, no duplicate-root warning, and no console errors.
- Verified `pnpm dev` with Playwright: one root, normal login rendering, and no console errors.

Closes #134