### PR TITLE
fix: use a relative URL for mocked login handler

### DIFF
--- a/web/src/mocks/browser.ts
+++ b/web/src/mocks/browser.ts
@@ -2,7 +2,7 @@ import { http, HttpResponse } from 'msw';
 import { setupWorker } from 'msw/browser';
 
 export const handlers = [
-  http.post('http://localhost/api/auth/login', () => {
+  http.post('/api/auth/login', () => {
     return HttpResponse.json({
       code: 0,
       data: {


### PR DESCRIPTION
## Summary

This PR addresses #135, where the mocked login handler only matches `http://localhost/api/auth/login`, while the default Vite development page runs at `http://localhost:3001`. The login request therefore falls through to Vite and returns `404`, leaving the login page displayed.

The handler now uses the same-origin relative path `/api/auth/login`. MSW resolves it against the current page origin, so the mocked login request matches the application request without depending on a fixed development port.

Before this change, `pnpm mocked` sent `POST http://localhost:3001/api/auth/login` but received `404 Not Found`. After this change, the same request receives the mocked `200 OK` response and the application navigates to `#/`.

## Changes

- Changed `web/src/mocks/browser.ts` to match `POST /api/auth/login` with a relative handler path.
- Preserved the existing mocked response `{ code: 0, data: { token: 'mocked_token' } }`.
- No backend, API client, Vite, or production runtime changes.

## Verification

- `pnpm exec tsc --noEmit`
- `pnpm build`
- `pnpm lint` (0 errors; 30 unrelated warnings remain)
- `git diff --check`
- Verified with Playwright while running `pnpm mocked` at `http://localhost:3001`: `POST /api/auth/login` returned `200 OK`, and the application navigated to `http://localhost:3001/#/`.

Closes #135