### PR TITLE
fix(web): improve mouse input reliability

### DIFF
--- a/web/src/lib/mouse.ts
+++ b/web/src/lib/mouse.ts
@@ -37,6 +37,10 @@ function getMouseButtonBit(button: number): number {
 export class MouseReportRelative {
   private buttons: number = 0;
 
+  get hasPressedButtons(): boolean {
+    return this.buttons !== 0;
+  }
+
   buttonDown(button: number): void {
     this.buttons |= getMouseButtonBit(button);
   }
@@ -89,6 +93,10 @@ export class MouseReportRelative {
 export class MouseReportAbsolute {
   private buttons: number = 0;
 
+  get hasPressedButtons(): boolean {
+    return this.buttons !== 0;
+  }
+
   buttonDown(button: number): void {
     this.buttons |= getMouseButtonBit(button);
   }
@@ -99,18 +107,20 @@ export class MouseReportAbsolute {
 
   /**
    * Build absolute mouse report
-   * @param x X position (0.0 to 1.0, normalized)
-   * @param y Y position (0.0 to 1.0, normalized)
+   * @param x X position (0 to 32767)
+   * @param y Y position (0 to 32767)
    * @param wheel Scroll wheel (-127 to 127)
    */
   buildReport(x: number, y: number, wheel: number = 0): Uint8Array {
     const report = new Uint8Array(6);
+    const positionX = this.clamp(Math.round(x), 0, 0x7fff);
+    const positionY = this.clamp(Math.round(y), 0, 0x7fff);
 
     report[0] = this.buttons;
-    report[1] = x & 0xff;
-    report[2] = (x >> 8) & 0xff;
-    report[3] = y & 0xff;
-    report[4] = (y >> 8) & 0xff;
+    report[1] = positionX & 0xff;
+    report[2] = (positionX >> 8) & 0xff;
+    report[3] = positionY & 0xff;
+    report[4] = (positionY >> 8) & 0xff;
     report[5] = this.clamp(Math.round(wheel), -127, 127) & 0xff;
 
     return report;
@@ -123,9 +133,9 @@ export class MouseReportAbsolute {
     return this.buildReport(lastX, lastY, 0);
   }
 
-  reset(): Uint8Array {
+  reset(lastX: number = 0, lastY: number = 0): Uint8Array {
     this.buttons = 0;
-    return this.buildReport(0, 0, 0);
+    return this.buildReport(lastX, lastY, 0);
   }
 
   private clamp(value: number, min: number, max: number): number {

--- a/web/src/lib/websocket.ts
+++ b/web/src/lib/websocket.ts
@@ -3,6 +3,7 @@ import { IMessageEvent, w3cwebsocket as W3cWebSocket } from 'websocket';
 import { getBaseUrl } from '@/lib/service.ts';
 
 type MessageHandler = (message: IMessageEvent) => void;
+type ConnectionHandler = () => void;
 type SendData = number[] | ArrayBuffer | Uint8Array;
 
 export enum MessageEvent {
@@ -34,6 +35,9 @@ export class WsClient {
   private shouldReconnect = true;
 
   private readonly eventHandlers = new Map<string, Set<MessageHandler>>();
+  // Connection hooks are separate from JSON message handlers and also run for explicit close().
+  private readonly openHandlers = new Set<ConnectionHandler>();
+  private readonly closeHandlers = new Set<ConnectionHandler>();
 
   constructor(options: WsClientOptions = {}) {
     this.options = { ...DEFAULT_OPTIONS, ...options };
@@ -49,11 +53,15 @@ export class WsClient {
     this.shouldReconnect = false;
     this.cleanup();
 
-    if (this.instance && this.instance.readyState === W3cWebSocket.OPEN) {
-      this.instance.close();
+    const instance = this.instance;
+    if (!instance) {
+      return;
     }
 
+    // Notify while the socket is still writable so input owners can send their neutral reports.
+    this.notifyConnectionHandlers(this.closeHandlers, 'close');
     this.instance = null;
+    this.closeConnection(instance);
   }
 
   public on(type: string, handler: MessageHandler): () => void {
@@ -88,15 +96,30 @@ export class WsClient {
     }
   }
 
+  public onOpen(handler: ConnectionHandler): () => void {
+    this.openHandlers.add(handler);
+    return () => this.openHandlers.delete(handler);
+  }
+
+  public onClose(handler: ConnectionHandler): () => void {
+    this.closeHandlers.add(handler);
+    return () => this.closeHandlers.delete(handler);
+  }
+
   public send(data: SendData): boolean {
     if (!this.instance || !this.isConnected) {
       return false;
     }
 
-    if (data instanceof ArrayBuffer || (data as unknown) instanceof Uint8Array) {
-      this.instance.send(data);
-    } else {
-      this.instance.send(JSON.stringify(data));
+    try {
+      if (data instanceof ArrayBuffer || (data as unknown) instanceof Uint8Array) {
+        this.instance.send(data);
+      } else {
+        this.instance.send(JSON.stringify(data));
+      }
+    } catch (error) {
+      console.error('[WebSocket] Send error:', error);
+      return false;
     }
 
     return true;
@@ -109,22 +132,54 @@ export class WsClient {
   private createConnection(): void {
     this.cleanup();
 
-    this.instance = new W3cWebSocket(this.options.url);
-    this.instance.binaryType = 'arraybuffer';
+    // Retire a replaced socket; identity checks below ignore any events it delivers later.
+    const previousInstance = this.instance;
+    if (previousInstance) {
+      this.instance = null;
+      this.closeConnection(previousInstance);
+    }
 
-    this.instance.onopen = this.handleOpen.bind(this);
-    this.instance.onclose = this.handleClose.bind(this);
-    this.instance.onerror = this.handleError.bind(this);
-    this.instance.onmessage = this.handleMessage.bind(this);
+    const instance = new W3cWebSocket(this.options.url);
+    instance.binaryType = 'arraybuffer';
+    this.instance = instance;
+
+    instance.onopen = () => {
+      // A CONNECTING socket may finish opening after close()/connect() has replaced it.
+      if (this.instance !== instance) {
+        this.closeConnection(instance);
+        return;
+      }
+      this.handleOpen();
+    };
+    instance.onclose = () => {
+      // Only the current socket may stop heartbeat, release input, or schedule reconnect.
+      if (this.instance !== instance) {
+        return;
+      }
+      this.instance = null;
+      this.handleClose();
+    };
+    instance.onerror = (error) => {
+      if (this.instance === instance) {
+        this.handleError(error);
+      }
+    };
+    instance.onmessage = (message) => {
+      if (this.instance === instance) {
+        this.handleMessage(message);
+      }
+    };
   }
 
   private handleOpen(): void {
     this.reconnectAttempts = 0;
+    this.notifyConnectionHandlers(this.openHandlers, 'open');
     this.startHeartbeat();
   }
 
   private handleClose(): void {
     this.stopHeartbeat();
+    this.notifyConnectionHandlers(this.closeHandlers, 'close');
     this.scheduleReconnect();
   }
 
@@ -184,6 +239,36 @@ export class WsClient {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
     }
+  }
+
+  private closeConnection(instance: W3cWebSocket): void {
+    // close() can race with CONNECTING; failure is harmless because stale callbacks are ignored.
+    if (
+      instance.readyState !== W3cWebSocket.CONNECTING &&
+      instance.readyState !== W3cWebSocket.OPEN
+    ) {
+      return;
+    }
+
+    try {
+      instance.close();
+    } catch (error) {
+      console.error('[WebSocket] Close error:', error);
+    }
+  }
+
+  private notifyConnectionHandlers(
+    handlers: Set<ConnectionHandler>,
+    event: 'close' | 'open'
+  ): void {
+    // One lifecycle consumer must not prevent heartbeat/reconnect or other cleanup handlers.
+    handlers.forEach((handler) => {
+      try {
+        handler();
+      } catch (error) {
+        console.error(`[WebSocket] ${event} handler error:`, error);
+      }
+    });
   }
 }
 

--- a/web/src/pages/desktop/index.tsx
+++ b/web/src/pages/desktop/index.tsx
@@ -14,6 +14,7 @@ import { Keyboard } from './keyboard';
 import { Menu } from './menu';
 import { Message } from './message.tsx';
 import { Mouse } from './mouse';
+import { initializeMouseInputLifecycle, releaseMouseInput } from './mouse/lifecycle.ts';
 import { Notification } from './notification.tsx';
 import { Screen } from './screen';
 import { VirtualKeyboard } from './virtual-keyboard';
@@ -25,12 +26,17 @@ export const Desktop = () => {
   const [videoMode, setVideoMode] = useAtom(videoModeAtom);
 
   useEffect(() => {
+    // Register mouse close/open hooks before the first WebSocket connection is created.
+    const disposeMouseInputLifecycle = initializeMouseInputLifecycle();
     client.connect();
 
     const mode = getVideoMode() as VideoMode;
     setVideoMode(mode);
 
     return () => {
+      // Release while the socket is writable, then detach hooks before the explicit close.
+      releaseMouseInput();
+      disposeMouseInputLifecycle();
       client.close();
     };
   }, []);

--- a/web/src/pages/desktop/menu/mouse/mouse-mode.tsx
+++ b/web/src/pages/desktop/menu/mouse/mouse-mode.tsx
@@ -4,8 +4,8 @@ import { CheckIcon, SquareDashedMousePointerIcon } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import * as ls from '@/lib/localstorage.ts';
-import { client } from '@/lib/websocket.ts';
 import { mouseModeAtom } from '@/jotai/mouse.ts';
+import { releaseMouseInput } from '@/pages/desktop/mouse/lifecycle.ts';
 
 export const MouseMode = () => {
   const { t } = useTranslation();
@@ -18,15 +18,12 @@ export const MouseMode = () => {
   ];
 
   function updateMouseMode(mode: string) {
+    if (mode === mouseMode) return;
+
+    // The old HID interface must receive neutral state before its component is replaced.
+    releaseMouseInput();
     setMouseMode(mode);
     ls.setMouseMode(mode);
-
-    if (mode === 'relative') {
-      client.close();
-      setTimeout(() => {
-        client.connect();
-      }, 500);
-    }
   }
 
   const content = (

--- a/web/src/pages/desktop/menu/mouse/reset-hid.tsx
+++ b/web/src/pages/desktop/menu/mouse/reset-hid.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 
 import * as api from '@/api/hid.ts';
 import { client, MessageEvent } from '@/lib/websocket.ts';
+import { releaseMouseInput } from '@/pages/desktop/mouse/lifecycle.ts';
 
 export const ResetHid = () => {
   const { t } = useTranslation();
@@ -14,6 +15,9 @@ export const ResetHid = () => {
   function resetHid() {
     if (isResetting) return;
     setIsResetting(true);
+
+    // Clear host-visible mouse state before resetting and reopening the gadget endpoints.
+    releaseMouseInput();
 
     // Release keyboard keys
     const data = new Uint8Array([MessageEvent.Keyboard, 0, 0, 0, 0, 0, 0, 0, 0]);

--- a/web/src/pages/desktop/mouse/absolute.tsx
+++ b/web/src/pages/desktop/mouse/absolute.tsx
@@ -4,10 +4,14 @@ import { useMediaQuery } from 'react-responsive';
 
 import { MouseReportAbsolute } from '@/lib/mouse.ts';
 import { getScreenElement, inverseRotatePoint, isQuarterTurn } from '@/lib/video-transform.ts';
-import { client, MessageEvent } from '@/lib/websocket.ts';
 import { scrollDirectionAtom, scrollIntervalAtom } from '@/jotai/mouse.ts';
 import { videoModeAtom, videoParametersAtom } from '@/jotai/screen.ts';
 
+import {
+  registerMouseReleaseHandler,
+  sendMouseRelease,
+  sendMouseReport
+} from './lifecycle.ts';
 import { MouseAbsoluteEvent } from './types.ts';
 
 enum MouseButton {
@@ -16,6 +20,11 @@ enum MouseButton {
   Right = 2,
   Back = 3,
   Forward = 4
+}
+
+interface ReleaseMouseOptions {
+  force?: boolean;
+  cancelTouchSequence?: boolean;
 }
 
 export const Absolute = () => {
@@ -27,16 +36,22 @@ export const Absolute = () => {
   const videoParameters = useAtomValue(videoParametersAtom);
 
   const mouseRef = useRef(new MouseReportAbsolute());
-  const lastPosRef = useRef({ x: 0.5, y: 0.5 });
+  // Absolute reports store HID coordinates, not normalized CSS coordinates.
+  const lastPosRef = useRef({ x: 0x4000, y: 0x4000 });
   const lastScrollTimeRef = useRef(0);
 
   // For touch events
   const touchStartTimeRef = useRef(0);
   const lastTouchYRef = useRef(0);
   const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const tapReleaseTimersRef = useRef(new Set<ReturnType<typeof setTimeout>>());
   const isLongPressRef = useRef(false);
   const hasMoveRef = useRef(false);
   const isDraggingRef = useRef(false);
+  const isMultiTouchRef = useRef(false);
+  // These refs prevent lifecycle-canceled touches from becoming a late tap/drag.
+  const activeTouchCountRef = useRef(0);
+  const isTouchSequenceCanceledRef = useRef(false);
   const pressedButtonRef = useRef<MouseButton | null>(null);
   const touchStartPosRef = useRef({ x: 0, y: 0 });
 
@@ -55,6 +70,11 @@ export const Absolute = () => {
     screen.addEventListener('wheel', handleWheel);
     screen.addEventListener('click', disableEvent);
     screen.addEventListener('contextmenu', disableEvent);
+    window.addEventListener('blur', handleWindowBlur);
+    window.addEventListener('mouseup', handleWindowMouseUp);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    const unregisterMouseReleaseHandler = registerMouseReleaseHandler(releaseMouse);
 
     if (isBigScreen) {
       screen.addEventListener('touchstart', handleTouchStart);
@@ -66,12 +86,14 @@ export const Absolute = () => {
     // Mouse down event
     function handleMouseDown(e: MouseEvent) {
       disableEvent(e);
+      lastPosRef.current = getCoordinate(e);
       handleMouseEvent({ type: 'mousedown', button: e.button });
     }
 
     // Mouse up event
     function handleMouseUp(e: MouseEvent) {
       disableEvent(e);
+      lastPosRef.current = getCoordinate(e);
       handleMouseEvent({ type: 'mouseup', button: e.button });
     }
 
@@ -100,6 +122,98 @@ export const Absolute = () => {
       lastScrollTimeRef.current = currentTime;
     }
 
+    function handleWindowBlur() {
+      releaseMouse();
+    }
+
+    function handleWindowMouseUp(e: MouseEvent) {
+      // Screen mouseup stops propagation; this catches releases outside the video element.
+      if (mouseRef.current.hasPressedButtons) {
+        handleMouseEvent({ type: 'mouseup', button: e.button });
+      }
+    }
+
+    function handleVisibilityChange() {
+      if (document.hidden) {
+        releaseMouse();
+      }
+    }
+
+    function clearTapReleaseTimers() {
+      // Multiple fast taps can have overlapping delayed releases.
+      for (const timer of tapReleaseTimersRef.current) {
+        clearTimeout(timer);
+      }
+      tapReleaseTimersRef.current.clear();
+    }
+
+    function releaseMouse(options: ReleaseMouseOptions = {}) {
+      const { force = false, cancelTouchSequence = true } = options;
+      const mouse = mouseRef.current;
+      const hadPressedButtons = mouse.hasPressedButtons;
+      const report = mouse.reset(lastPosRef.current.x, lastPosRef.current.y);
+
+      // Keep the cancellation gate until every still-active browser touch has ended.
+      if (cancelTouchSequence && activeTouchCountRef.current > 0) {
+        isTouchSequenceCanceledRef.current = true;
+      }
+
+      if (longPressTimerRef.current) {
+        clearTimeout(longPressTimerRef.current);
+        longPressTimerRef.current = null;
+      }
+
+      clearTapReleaseTimers();
+
+      touchStartTimeRef.current = 0;
+      lastTouchYRef.current = 0;
+      lastScrollTimeRef.current = 0;
+      isLongPressRef.current = false;
+      hasMoveRef.current = false;
+      isDraggingRef.current = false;
+      isMultiTouchRef.current = false;
+      pressedButtonRef.current = null;
+      touchStartPosRef.current = { x: 0, y: 0 };
+
+      // Reset local state first; queue the host-visible neutral report if transport is down.
+      if (hadPressedButtons || force) {
+        sendMouseRelease('absolute', report);
+      }
+    }
+
+    function handleMouseEvent(event: MouseAbsoluteEvent): boolean {
+      let report: Uint8Array;
+      const mouse = mouseRef.current;
+
+      switch (event.type) {
+        case 'mousedown':
+          mouse.buttonDown(event.button);
+          report = mouse.buildButtonReport(lastPosRef.current.x, lastPosRef.current.y);
+          break;
+        case 'mouseup':
+          mouse.buttonUp(event.button);
+          report = mouse.buildButtonReport(lastPosRef.current.x, lastPosRef.current.y);
+          break;
+        case 'wheel':
+          report = mouse.buildReport(lastPosRef.current.x, lastPosRef.current.y, event.deltaY);
+          break;
+        case 'move':
+          report = mouse.buildReport(event.x, event.y);
+          lastPosRef.current = { x: event.x, y: event.y };
+          break;
+        default:
+          report = mouse.buildReport(lastPosRef.current.x, lastPosRef.current.y);
+          break;
+      }
+
+      const sent = sendMouseReport('absolute', report);
+      if (!sent && (event.type === 'mouseup' || mouse.hasPressedButtons)) {
+        releaseMouse({ force: true });
+      }
+
+      return sent;
+    }
+
     // Mouse touch start event
     function handleTouchStart(e: TouchEvent) {
       disableEvent(e);
@@ -108,7 +222,26 @@ export const Absolute = () => {
         return;
       }
 
+      const startsNewSequence = e.touches.length === e.changedTouches.length;
+      if (startsNewSequence) {
+        // Browsers may omit the old final touchend; settle all stale state before a new gesture.
+        releaseMouse({ cancelTouchSequence: false });
+        isTouchSequenceCanceledRef.current = false;
+      }
+      activeTouchCountRef.current = e.touches.length;
+      if (isTouchSequenceCanceledRef.current) {
+        return;
+      }
+
       const touch = e.touches[0];
+
+      if (e.touches.length > 1) {
+        // Entering multi-touch ends any single-finger drag/long-press before scrolling.
+        releaseMouse({ cancelTouchSequence: false });
+        isMultiTouchRef.current = true;
+        lastTouchYRef.current = touch.clientY;
+        return;
+      }
 
       // Reset states
       touchStartTimeRef.current = Date.now();
@@ -124,14 +257,15 @@ export const Absolute = () => {
       }
 
       const { x, y } = getCoordinate(touch);
-      handleMouseEvent({ type: 'move', x, y });
-
-      if (e.touches.length > 1) {
+      if (!handleMouseEvent({ type: 'move', x, y })) {
+        // Do not create a long-press timer for a gesture whose initial position was not sent.
+        isTouchSequenceCanceledRef.current = true;
         return;
       }
 
       // Start long press
       longPressTimerRef.current = setTimeout(() => {
+        longPressTimerRef.current = null;
         isLongPressRef.current = true;
         pressedButtonRef.current = MouseButton.Right;
         if (navigator.vibrate) {
@@ -146,13 +280,23 @@ export const Absolute = () => {
     function handleTouchMove(e: TouchEvent) {
       disableEvent(e);
 
+      activeTouchCountRef.current = e.touches.length;
+      if (isTouchSequenceCanceledRef.current) {
+        return;
+      }
+
       if (e.touches.length === 0) {
         return;
       }
       const touch = e.touches[0];
 
-      // Handle two-finger scroll first
-      if (e.touches.length > 1) {
+      // Once a gesture becomes multi-touch, do not reinterpret the remaining
+      // finger as a tap or drag after another finger is lifted.
+      if (isMultiTouchRef.current) {
+        if (e.touches.length < 2) {
+          return;
+        }
+
         const currentTime = Date.now();
         if (currentTime - lastScrollTimeRef.current < scrollInterval) {
           return;
@@ -207,16 +351,40 @@ export const Absolute = () => {
     function handleTouchEnd(e: TouchEvent) {
       disableEvent(e);
 
+      activeTouchCountRef.current = e.touches.length;
+
       if (longPressTimerRef.current) {
         clearTimeout(longPressTimerRef.current);
         longPressTimerRef.current = null;
       }
 
+      if (isTouchSequenceCanceledRef.current) {
+        // A lifecycle release owns this sequence until its final touch disappears.
+        if (e.touches.length === 0) {
+          isTouchSequenceCanceledRef.current = false;
+        }
+        return;
+      }
+
+      if (isMultiTouchRef.current) {
+        if (e.touches.length === 0) {
+          isMultiTouchRef.current = false;
+          lastTouchYRef.current = 0;
+          lastScrollTimeRef.current = 0;
+        }
+        return;
+      }
+
       if (!hasMoveRef.current && !isLongPressRef.current) {
-        handleMouseEvent({ type: 'mousedown', button: MouseButton.Left });
-        setTimeout(() => {
+        const sent = handleMouseEvent({ type: 'mousedown', button: MouseButton.Left });
+        if (!sent) {
+          return;
+        }
+        const timer = setTimeout(() => {
           handleMouseEvent({ type: 'mouseup', button: MouseButton.Left });
+          tapReleaseTimersRef.current.delete(timer);
         }, 50);
+        tapReleaseTimersRef.current.add(timer);
       } else if (pressedButtonRef.current !== null) {
         handleMouseEvent({ type: 'mouseup', button: pressedButtonRef.current! });
       }
@@ -228,22 +396,13 @@ export const Absolute = () => {
     }
 
     // Mouse touch cancel event
-    function handleTouchCancel(e: any) {
+    function handleTouchCancel(e: TouchEvent) {
       disableEvent(e);
-
-      if (longPressTimerRef.current) {
-        clearTimeout(longPressTimerRef.current);
-        longPressTimerRef.current = null;
+      activeTouchCountRef.current = e.touches.length;
+      releaseMouse();
+      if (e.touches.length === 0) {
+        isTouchSequenceCanceledRef.current = false;
       }
-
-      if (pressedButtonRef.current) {
-        handleMouseEvent({ type: 'mouseup', button: pressedButtonRef.current! });
-      }
-
-      isLongPressRef.current = false;
-      hasMoveRef.current = false;
-      isDraggingRef.current = false;
-      pressedButtonRef.current = null;
     }
 
     // get mouse coordinate
@@ -253,8 +412,9 @@ export const Absolute = () => {
       const finalX = Math.max(0, Math.min(1, x));
       const finalY = Math.max(0, Math.min(1, y));
 
-      const hexX = Math.floor(0x7fff * finalX) + 0x0001;
-      const hexY = Math.floor(0x7fff * finalY) + 0x0001;
+      // Map rendered video space onto the GS2 15-bit absolute coordinate range.
+      const hexX = Math.round(0x7fff * finalX);
+      const hexY = Math.round(0x7fff * finalY);
 
       return { x: hexX, y: hexY };
     }
@@ -295,6 +455,9 @@ export const Absolute = () => {
     }
 
     return () => {
+      releaseMouse();
+      unregisterMouseReleaseHandler();
+
       screen.removeEventListener('mousemove', handleMouseMove);
       screen.removeEventListener('mousedown', handleMouseDown);
       screen.removeEventListener('mouseup', handleMouseUp);
@@ -305,46 +468,11 @@ export const Absolute = () => {
       screen.removeEventListener('touchmove', handleTouchMove);
       screen.removeEventListener('touchend', handleTouchEnd);
       screen.removeEventListener('touchcancel', handleTouchCancel);
-
-      if (longPressTimerRef.current) {
-        clearTimeout(longPressTimerRef.current);
-      }
+      window.removeEventListener('blur', handleWindowBlur);
+      window.removeEventListener('mouseup', handleWindowMouseUp);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
   }, [isBigScreen, scrollDirection, scrollInterval, videoMode, videoParameters.rotation]);
-
-  // Mouse event handler
-  function handleMouseEvent(event: MouseAbsoluteEvent) {
-    let report: Uint8Array;
-    const mouse = mouseRef.current;
-
-    switch (event.type) {
-      case 'mousedown':
-        mouse.buttonDown(event.button);
-        report = mouse.buildButtonReport(lastPosRef.current.x, lastPosRef.current.y);
-        break;
-      case 'mouseup':
-        mouse.buttonUp(event.button);
-        report = mouse.buildButtonReport(lastPosRef.current.x, lastPosRef.current.y);
-        break;
-      case 'wheel':
-        report = mouse.buildReport(lastPosRef.current.x, lastPosRef.current.y, event.deltaY);
-        break;
-      case 'move':
-        report = mouse.buildReport(event.x, event.y);
-        lastPosRef.current = { x: event.x, y: event.y };
-        break;
-      default:
-        report = mouse.buildReport(lastPosRef.current.x, lastPosRef.current.y);
-        break;
-    }
-
-    sendReport(report);
-  }
-
-  function sendReport(report: Uint8Array) {
-    const data = new Uint8Array([MessageEvent.Mouse, ...report]);
-    client.send(data);
-  }
 
   // disable default events
   function disableEvent(event: any) {

--- a/web/src/pages/desktop/mouse/lifecycle.ts
+++ b/web/src/pages/desktop/mouse/lifecycle.ts
@@ -1,0 +1,77 @@
+import { client, MessageEvent } from '@/lib/websocket.ts';
+
+/**
+ * Coordinates mouse state across mode components and WebSocket reconnects.
+ * Reports queued here outlive an Absolute/Relative component unmount.
+ */
+type ReleaseHandler = () => void;
+export type MouseInterface = 'absolute' | 'relative';
+
+let releaseHandler: ReleaseHandler | null = null;
+// Each HID interface needs its own neutral report because report length selects hidg1/hidg2.
+const pendingReleases = new Map<MouseInterface, Uint8Array>();
+
+function buildMouseMessage(report: Uint8Array): Uint8Array {
+  return new Uint8Array([MessageEvent.Mouse, ...report]);
+}
+
+function flushPendingMouseReleases(): boolean {
+  // A stale release must reach the host before any input from a new mode/connection.
+  for (const [mouseInterface, data] of pendingReleases) {
+    if (client.send(data)) {
+      pendingReleases.delete(mouseInterface);
+    }
+  }
+
+  return pendingReleases.size === 0;
+}
+
+export function initializeMouseInputLifecycle(): () => void {
+  // Unexpected close clears local button state; open retries the matching HID releases first.
+  const removeOpenHandler = client.onOpen(flushPendingMouseReleases);
+  const removeCloseHandler = client.onClose(releaseMouseInput);
+
+  return () => {
+    removeOpenHandler();
+    removeCloseHandler();
+  };
+}
+
+export function sendMouseReport(mouseInterface: MouseInterface, report: Uint8Array): boolean {
+  // Do not let a new press overtake a neutral report left behind by a broken connection.
+  if (!flushPendingMouseReleases()) {
+    return false;
+  }
+
+  const sent = client.send(buildMouseMessage(report));
+  if (sent && report[0] === 0) {
+    pendingReleases.delete(mouseInterface);
+  }
+
+  return sent;
+}
+
+export function sendMouseRelease(mouseInterface: MouseInterface, report: Uint8Array): void {
+  const data = buildMouseMessage(report);
+  // Record first, then remove only after send accepted the complete neutral report.
+  pendingReleases.set(mouseInterface, data);
+
+  if (client.send(data)) {
+    pendingReleases.delete(mouseInterface);
+  }
+}
+
+export function registerMouseReleaseHandler(handler: ReleaseHandler): () => void {
+  // Only the mounted mouse mode owns the current local button/touch state.
+  releaseHandler = handler;
+
+  return () => {
+    if (releaseHandler === handler) {
+      releaseHandler = null;
+    }
+  };
+}
+
+export function releaseMouseInput(): void {
+  releaseHandler?.();
+}

--- a/web/src/pages/desktop/mouse/relative.tsx
+++ b/web/src/pages/desktop/mouse/relative.tsx
@@ -5,10 +5,14 @@ import { useTranslation } from 'react-i18next';
 
 import { MouseReportRelative } from '@/lib/mouse.ts';
 import { getScreenElement, inverseRotateDelta } from '@/lib/video-transform.ts';
-import { client, MessageEvent } from '@/lib/websocket.ts';
 import { scrollDirectionAtom, scrollIntervalAtom } from '@/jotai/mouse.ts';
 import { videoModeAtom, videoParametersAtom } from '@/jotai/screen.ts';
 
+import {
+  registerMouseReleaseHandler,
+  sendMouseRelease,
+  sendMouseReport
+} from './lifecycle.ts';
 import { MouseRelativeEvent } from './types.ts';
 
 export const Relative = () => {
@@ -24,35 +28,6 @@ export const Relative = () => {
   const isLockedRef = useRef(false);
   const lastScrollTimeRef = useRef(0);
 
-  // Mouse handler
-  function handleMouseEvent(event: MouseRelativeEvent) {
-    let report: Uint8Array;
-    const mouse = mouseRef.current;
-
-    switch (event.type) {
-      case 'mousedown':
-        mouse.buttonDown(event.button);
-        report = mouse.buildButtonReport();
-        break;
-      case 'mouseup':
-        mouse.buttonUp(event.button);
-        report = mouse.buildButtonReport();
-        break;
-      case 'wheel':
-        report = mouse.buildReport(0, 0, event.deltaY);
-        break;
-      case 'move':
-        report = mouse.buildReport(event.deltaX, event.deltaY);
-        break;
-      default:
-        report = mouse.buildReport(0, 0);
-        break;
-    }
-
-    const data = new Uint8Array([MessageEvent.Mouse, ...report]);
-    client.send(data);
-  }
-
   useEffect(() => {
     const screen = getScreenElement();
     if (!screen) return;
@@ -66,6 +41,41 @@ export const Relative = () => {
     screen.addEventListener('wheel', handleMouseWheel, { passive: false });
     screen.addEventListener('contextmenu', handleContextMenu);
     document.addEventListener('pointerlockchange', handlePointerLockChange);
+    window.addEventListener('blur', handleWindowBlur);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    const unregisterMouseReleaseHandler = registerMouseReleaseHandler(releaseMouseAndExitPointerLock);
+
+    // Mouse event handler: keep local button state even when movement reports are separate.
+    function handleMouseEvent(event: MouseRelativeEvent) {
+      let report: Uint8Array;
+      const mouse = mouseRef.current;
+
+      switch (event.type) {
+        case 'mousedown':
+          mouse.buttonDown(event.button);
+          report = mouse.buildButtonReport();
+          break;
+        case 'mouseup':
+          mouse.buttonUp(event.button);
+          report = mouse.buildButtonReport();
+          break;
+        case 'wheel':
+          report = mouse.buildReport(0, 0, event.deltaY);
+          break;
+        case 'move':
+          report = mouse.buildReport(event.deltaX, event.deltaY);
+          break;
+        default:
+          report = mouse.buildReport(0, 0);
+          break;
+      }
+
+      const sent = sendMouseReport('relative', report);
+      if (!sent && (event.type === 'mouseup' || mouse.hasPressedButtons)) {
+        releaseMouse(true);
+      }
+    }
 
     function handleContextMenu(event: Event) {
       event.preventDefault();
@@ -126,10 +136,52 @@ export const Relative = () => {
     }
 
     function handlePointerLockChange() {
-      isLockedRef.current = document.pointerLockElement === screen;
+      const wasLocked = isLockedRef.current;
+      const isLocked = document.pointerLockElement === screen;
+      isLockedRef.current = isLocked;
+
+      // Esc/browser policy can drop pointer lock without delivering the matching mouseup.
+      if (wasLocked && !isLocked) {
+        releaseMouse();
+      }
+    }
+
+    function handleWindowBlur() {
+      releaseMouseAndExitPointerLock();
+    }
+
+    function handleVisibilityChange() {
+      if (document.hidden) {
+        releaseMouseAndExitPointerLock();
+      }
+    }
+
+    function releaseMouse(force = false) {
+      const mouse = mouseRef.current;
+      const hadPressedButtons = mouse.hasPressedButtons;
+      const report = mouse.reset();
+      lastScrollTimeRef.current = 0;
+
+      // Local state is reset immediately; lifecycle.ts retains remote release on send failure.
+      if (hadPressedButtons || force) {
+        sendMouseRelease('relative', report);
+      }
+    }
+
+    function releaseMouseAndExitPointerLock() {
+      releaseMouse();
+
+      if (document.pointerLockElement === screen) {
+        document.exitPointerLock();
+      }
+
+      isLockedRef.current = false;
     }
 
     return () => {
+      releaseMouseAndExitPointerLock();
+      unregisterMouseReleaseHandler();
+
       screen.removeEventListener('click', handleMouseClick);
       screen.removeEventListener('mousemove', handleMouseMove);
       screen.removeEventListener('mousedown', handleMouseDown);
@@ -137,6 +189,8 @@ export const Relative = () => {
       screen.removeEventListener('wheel', handleMouseWheel);
       screen.removeEventListener('contextmenu', handleContextMenu);
       document.removeEventListener('pointerlockchange', handlePointerLockChange);
+      window.removeEventListener('blur', handleWindowBlur);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
   }, [scrollDirection, scrollInterval, videoMode, videoParameters.rotation]);
 


### PR DESCRIPTION
## Summary

This PR improves remote mouse reliability across connection changes, input-mode transitions, and browser lifecycle events.

Mouse button state is now released consistently when the WebSocket disconnects, the page loses focus or visibility, pointer lock ends, touch input is interrupted, or the user switches mouse modes. Failed release reports are retained and replayed after reconnection so that a transient connection loss does not leave a button pressed on the target host.

The change also tightens absolute-coordinate handling at display boundaries and removes an unnecessary reconnect when changing mouse modes.

## Changes

- Centralize mouse-button release handling for absolute and relative input.
- Track pending releases when a neutral HID report cannot be sent, then flush both mouse interfaces after reconnection.
- Release held buttons on blur, visibility changes, pointer-lock loss, touch cancellation, unmount, and mouse-mode transitions.
- Keep release handling isolated from stale component state during asynchronous lifecycle events.
- Clamp and normalize absolute coordinates at the valid HID report boundaries.
- Avoid reconnecting the WebSocket solely because the selected mouse mode changes.
- Preserve browser Back and Forward mouse buttons in both input modes.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `git diff --check`

## Manual Testing

Test topology: Microsoft Edge on an Android tablet as the Web client, with a Windows PC as the controlled host.

- [x] Absolute-mode movement, clicking, dragging, and positioning at all screen edges and corners work correctly.
- [x] Relative-mode movement, clicking, dragging, and scrolling work correctly with a physical mouse connected to the Android tablet.