### PR TITLE
fix: prevent virtual keyboard crash

### DIFF
--- a/web/src/pages/desktop/virtual-keyboard/index.tsx
+++ b/web/src/pages/desktop/virtual-keyboard/index.tsx
@@ -3,7 +3,7 @@ import { AppleOutlined, WindowsOutlined } from '@ant-design/icons';
 import clsx from 'clsx';
 import { useAtom } from 'jotai';
 import { XIcon } from 'lucide-react';
-import Keyboard, { KeyboardButtonTheme } from 'react-simple-keyboard';
+import { KeyboardButtonTheme, KeyboardReact as Keyboard } from 'react-simple-keyboard';
 import { Drawer } from 'vaul';
 
 import 'react-simple-keyboard/build/css/index.css';


### PR DESCRIPTION
## Summary

Use `react-simple-keyboard`'s named `KeyboardReact` export so the Vite 8 production build renders the component instead of its wrapped CommonJS module object. This prevents React error #130 from crashing the remote desktop page when the virtual keyboard is opened.

## Verification

- `pnpm run build`
- Opened, closed, and reopened the virtual keyboard with Playwright at desktop and narrow viewport sizes
- `git diff --check`

Fixes #147