### PR TITLE
Add support for pasting Russian text

### DIFF
--- a/web/src/i18n/locales/de.ts
+++ b/web/src/i18n/locales/de.ts
@@ -54,7 +54,9 @@ const de = {
       placeholder: 'Bitte eingeben',
       submit: 'Senden',
       virtual: 'Tastatur',
-      ctrlaltdel: 'Ctrl+Alt+Del'
+      ctrlaltdel: 'Ctrl+Alt+Del',
+      dropdownEnglish: 'Englisch',
+      dropdownRussian: 'Russisch'
     },
     mouse: {
       title: 'Maus',

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -110,6 +110,9 @@ const en = {
       placeholder: 'Please input',
       submit: 'Submit',
       virtual: 'Keyboard',
+      ctrlaltdel: 'Ctrl+Alt+Del',
+      dropdownEnglish: 'English',
+      dropdownRussian: 'Russian',
       shortcut: {
         title: 'Shortcuts',
         custom: 'Custom',

--- a/web/src/i18n/locales/ru.ts
+++ b/web/src/i18n/locales/ru.ts
@@ -104,7 +104,9 @@ const ru = {
       placeholder: 'Текст для ввода',
       submit: 'Вставить',
       virtual: 'Клавиатура',
-      ctrlaltdel: 'Ctrl+Alt+Del'
+      ctrlaltdel: 'Ctrl+Alt+Del',
+      dropdownEnglish: 'Английский',
+      dropdownRussian: 'Русский'
     },
     mouse: {
       title: 'Мышь',


### PR DESCRIPTION
## Summary
- Translate pasted Russian text into the corresponding keyboard keys
- Avoid errors when pasting non-ASCII Russian letters

This is the paste-only part previously mixed into #111. Independent of the virtual keyboard mapping fix.

## Test plan
- [ ] Paste Russian text via the keyboard paste menu
- [ ] Confirm it is typed on the target machine
- [ ] Confirm mixed/non-ASCII Russian input does not error