### PR TITLE
feat: add web display policy controls

### DIFF
--- a/server/proto/vm.go
+++ b/server/proto/vm.go
@@ -110,6 +110,33 @@ type SetLcdScreenOffReq struct {
 	EndMinute   *int  `json:"endMinute"`
 }
 
+type LcdDisplaySchedule struct {
+	Supported          bool `json:"supported"`
+	Enabled            bool `json:"enabled"`
+	StartMinute        int  `json:"startMinute"`
+	EndMinute          int  `json:"endMinute"`
+	WakeTimeoutSeconds int  `json:"wakeTimeoutSeconds,omitempty"`
+}
+
+type GetLcdDisplayPolicyRsp struct {
+	ScreenType         string             `json:"screenType"`
+	SupportedModes     []string           `json:"supportedModes"`
+	Mode               string             `json:"mode,omitempty"`
+	ModeTimeoutSeconds map[string]int     `json:"modeTimeoutSeconds,omitempty"`
+	Schedule           LcdDisplaySchedule `json:"schedule"`
+}
+
+type SetLcdDisplayPolicyReq struct {
+	Mode     *string                `json:"mode"`
+	Schedule *SetLcdDisplaySchedule `json:"schedule"`
+}
+
+type SetLcdDisplaySchedule struct {
+	Enabled     *bool `json:"enabled"`
+	StartMinute *int  `json:"startMinute"`
+	EndMinute   *int  `json:"endMinute"`
+}
+
 type GetSSHStateRsp struct {
 	Enabled bool `json:"enabled"`
 }

--- a/server/router/vm.go
+++ b/server/router/vm.go
@@ -29,12 +29,14 @@ func vmRouter(r *gin.Engine) {
 	api.POST("/vm/device/virtual", service.UpdateVirtualDevice)          // update virtual device
 	api.POST("/vm/device/virtual/refresh", service.RefreshVirtualDevice) // refresh virtual device
 
-	api.GET("/vm/oled", service.GetOLED)                      // get OLED configuration
-	api.POST("/vm/oled", service.SetOLED)                     // set OLED configuration
-	api.GET("/vm/lcd/time/format", service.GetLcdTimeFormat)  // get LCD time format
-	api.POST("/vm/lcd/time/format", service.SetLcdTimeFormat) // set LCD time format
-	api.GET("/vm/lcd/screen-off", service.GetLcdScreenOff)    // get LCD screen-off schedule
-	api.POST("/vm/lcd/screen-off", service.SetLcdScreenOff)   // set LCD screen-off schedule
+	api.GET("/vm/oled", service.GetOLED)                            // get OLED configuration
+	api.POST("/vm/oled", service.SetOLED)                           // set OLED configuration
+	api.GET("/vm/lcd/time/format", service.GetLcdTimeFormat)        // get LCD time format
+	api.POST("/vm/lcd/time/format", service.SetLcdTimeFormat)       // set LCD time format
+	api.GET("/vm/lcd/screen-off", service.GetLcdScreenOff)          // get LCD screen-off schedule
+	api.POST("/vm/lcd/screen-off", service.SetLcdScreenOff)         // set LCD screen-off schedule
+	api.GET("/vm/lcd/display-policy", service.GetLcdDisplayPolicy)  // get LCD display policy
+	api.POST("/vm/lcd/display-policy", service.SetLcdDisplayPolicy) // set LCD display policy
 
 	api.GET("/vm/hdmi/capture", service.GetHdmiCapture)          // get HDMI capture status
 	api.POST("/vm/hdmi/capture", service.SetHdmiCapture)         // set HDMI capture status

--- a/server/service/ui/displaypolicy.go
+++ b/server/service/ui/displaypolicy.go
@@ -1,0 +1,181 @@
+package ui
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// DisplayPolicy is the combined idle-display and scheduled screen-off state
+// exposed by newer kvm_ui versions.
+type DisplayPolicy struct {
+	SupportedModes     []string        `json:"supported_modes"`
+	Mode               string          `json:"mode"`
+	ModeTimeoutSeconds map[string]int  `json:"mode_timeout_seconds,omitempty"`
+	Schedule           DisplaySchedule `json:"schedule"`
+}
+
+type DisplaySchedule struct {
+	Supported          bool `json:"supported"`
+	Enabled            bool `json:"enabled"`
+	StartMinute        int  `json:"start_minute"`
+	EndMinute          int  `json:"end_minute"`
+	WakeTimeoutSeconds int  `json:"wake_timeout_seconds,omitempty"`
+}
+
+type DisplayPolicyUpdate struct {
+	Mode     *string          `json:"mode,omitempty"`
+	Schedule *DisplaySchedule `json:"schedule,omitempty"`
+}
+
+func GetDisplayPolicy() (*DisplayPolicy, error) {
+	data, err := Get("/display-policy/get")
+	if err != nil {
+		return nil, err
+	}
+
+	var policy DisplayPolicy
+	if err := decodeDisplayPolicy(data, &policy); err != nil {
+		return nil, fmt.Errorf("decode display policy: %w", err)
+	}
+	if err := validateDisplayPolicy(policy); err != nil {
+		return nil, fmt.Errorf("invalid display policy response: %w", err)
+	}
+	return &policy, nil
+}
+
+func decodeDisplayPolicy(data []byte, policy *DisplayPolicy) error {
+	var wire struct {
+		Mode               *string        `json:"mode"`
+		SupportedModes     *[]string      `json:"supported_modes"`
+		ModeTimeoutSeconds map[string]int `json:"mode_timeout_seconds"`
+		Schedule           *struct {
+			Supported          *bool `json:"supported"`
+			Enabled            *bool `json:"enabled"`
+			StartMinute        *int  `json:"start_minute"`
+			EndMinute          *int  `json:"end_minute"`
+			WakeTimeoutSeconds *int  `json:"wake_timeout_seconds"`
+		} `json:"schedule"`
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	if err := decoder.Decode(&wire); err != nil {
+		return err
+	}
+	var trailing interface{}
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("unexpected trailing JSON data")
+		}
+		return err
+	}
+	if wire.Mode == nil || *wire.Mode == "" {
+		return fmt.Errorf("missing required mode")
+	}
+	if wire.SupportedModes == nil || len(*wire.SupportedModes) == 0 {
+		return fmt.Errorf("missing required supported_modes")
+	}
+	if wire.Schedule == nil || wire.Schedule.Supported == nil || wire.Schedule.Enabled == nil ||
+		wire.Schedule.StartMinute == nil || wire.Schedule.EndMinute == nil ||
+		wire.Schedule.WakeTimeoutSeconds == nil {
+		return fmt.Errorf("missing required schedule fields")
+	}
+	seen := make(map[string]struct{}, len(*wire.SupportedModes))
+	for _, mode := range *wire.SupportedModes {
+		if mode == "" {
+			return fmt.Errorf("supported_modes contains an empty mode")
+		}
+		if _, ok := seen[mode]; ok {
+			return fmt.Errorf("supported_modes contains duplicate mode %q", mode)
+		}
+		seen[mode] = struct{}{}
+	}
+	if _, ok := seen[*wire.Mode]; !ok {
+		return fmt.Errorf("mode %q is not supported", *wire.Mode)
+	}
+	policy.Mode = *wire.Mode
+	policy.SupportedModes = append([]string(nil), (*wire.SupportedModes)...)
+	policy.ModeTimeoutSeconds = wire.ModeTimeoutSeconds
+	policy.Schedule = DisplaySchedule{
+		Supported:          *wire.Schedule.Supported,
+		Enabled:            *wire.Schedule.Enabled,
+		StartMinute:        *wire.Schedule.StartMinute,
+		EndMinute:          *wire.Schedule.EndMinute,
+		WakeTimeoutSeconds: *wire.Schedule.WakeTimeoutSeconds,
+	}
+	return nil
+}
+
+func SetDisplayPolicy(update DisplayPolicyUpdate) error {
+	if err := validateDisplayPolicyUpdate(update); err != nil {
+		return err
+	}
+	data, err := json.Marshal(update)
+	if err != nil {
+		return err
+	}
+	rspData, err := Post("/display-policy/set", data)
+	if err != nil {
+		return err
+	}
+	var rsp struct {
+		Status  string      `json:"status"`
+		Message interface{} `json:"message"`
+	}
+	if err := json.Unmarshal(rspData, &rsp); err != nil {
+		return fmt.Errorf("decode display policy response: %w", err)
+	}
+	if rsp.Status != "ok" {
+		return fmt.Errorf("set display policy failed: %v", rsp.Message)
+	}
+	return nil
+}
+
+func validateDisplayPolicy(policy DisplayPolicy) error {
+	if policy.Mode == "" || len(policy.SupportedModes) == 0 {
+		return fmt.Errorf("mode and supported_modes are required")
+	}
+	found := false
+	for _, mode := range policy.SupportedModes {
+		if mode == policy.Mode {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("mode %q is not supported", policy.Mode)
+	}
+	if err := validateSchedule(policy.Schedule.Enabled, policy.Schedule.StartMinute, policy.Schedule.EndMinute); err != nil {
+		return err
+	}
+	if policy.Schedule.WakeTimeoutSeconds < 0 ||
+		(policy.Schedule.Supported && policy.Schedule.WakeTimeoutSeconds == 0) {
+		return fmt.Errorf("invalid schedule wake timeout")
+	}
+	return nil
+}
+
+func validateDisplayPolicyUpdate(update DisplayPolicyUpdate) error {
+	if update.Mode == nil && update.Schedule == nil {
+		return fmt.Errorf("display policy update is empty")
+	}
+	if update.Mode != nil && *update.Mode == "" {
+		return fmt.Errorf("mode is required")
+	}
+	if update.Schedule != nil {
+		if err := validateSchedule(update.Schedule.Enabled, update.Schedule.StartMinute, update.Schedule.EndMinute); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateSchedule(enabled bool, startMinute int, endMinute int) error {
+	if startMinute < 0 || startMinute >= minutesPerDay || endMinute < 0 || endMinute >= minutesPerDay {
+		return fmt.Errorf("screen-off minutes must be between 0 and %d", minutesPerDay-1)
+	}
+	if enabled && startMinute == endMinute {
+		return fmt.Errorf("screen-off start and end minutes must differ")
+	}
+	return nil
+}

--- a/server/service/ui/displaypolicy_test.go
+++ b/server/service/ui/displaypolicy_test.go
@@ -1,0 +1,35 @@
+package ui
+
+import "testing"
+
+func TestDecodeDisplayPolicyRejectsIncompleteResponses(t *testing.T) {
+	tests := []string{
+		`{}`,
+		`{"mode":"idleClock","supported_modes":[],"schedule":{"supported":true,"enabled":false,"start_minute":0,"end_minute":0,"wake_timeout_seconds":60}}`,
+		`{"mode":"idleClock","supported_modes":["alwaysOn"],"schedule":{"supported":true,"enabled":false,"start_minute":0,"end_minute":0,"wake_timeout_seconds":60}}`,
+		`{"mode":"idleClock","supported_modes":["idleClock"],"schedule":{"supported":true,"enabled":false,"start_minute":0,"end_minute":0}}`,
+		`{"mode":"idleClock","supported_modes":["idleClock"],"schedule":{"supported":true,"enabled":true,"start_minute":10,"end_minute":10,"wake_timeout_seconds":60}}`,
+		`{"mode":"idleClock","supported_modes":["idleClock"],"schedule":{"supported":true,"enabled":false,"start_minute":0,"end_minute":0,"wake_timeout_seconds":60}}{}`,
+	}
+	for _, input := range tests {
+		var policy DisplayPolicy
+		err := decodeDisplayPolicy([]byte(input), &policy)
+		if err == nil {
+			err = validateDisplayPolicy(policy)
+		}
+		if err == nil {
+			t.Errorf("display policy response %s unexpectedly passed validation", input)
+		}
+	}
+}
+
+func TestDecodeDisplayPolicyAcceptsCompleteResponse(t *testing.T) {
+	var policy DisplayPolicy
+	input := `{"mode":"idleClock","supported_modes":["alwaysOn","idleClock","idleOff"],"mode_timeout_seconds":{"idleClock":20,"idleOff":60},"schedule":{"supported":true,"enabled":true,"start_minute":1020,"end_minute":540,"wake_timeout_seconds":60}}`
+	if err := decodeDisplayPolicy([]byte(input), &policy); err != nil {
+		t.Fatalf("decodeDisplayPolicy() error = %v", err)
+	}
+	if err := validateDisplayPolicy(policy); err != nil {
+		t.Fatalf("validateDisplayPolicy() error = %v", err)
+	}
+}

--- a/server/service/ui/http.go
+++ b/server/service/ui/http.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -13,6 +14,19 @@ import (
 const (
 	BaseURL = "http://127.0.0.1:65501/api"
 )
+
+type HTTPStatusError struct {
+	StatusCode int
+}
+
+func (e *HTTPStatusError) Error() string {
+	return fmt.Sprintf("status code %d", e.StatusCode)
+}
+
+func IsNotFound(err error) bool {
+	var statusErr *HTTPStatusError
+	return errors.As(err, &statusErr) && statusErr.StatusCode == http.StatusNotFound
+}
 
 func Get(url string) ([]byte, error) {
 	resp, err := http.Get(BaseURL + url)
@@ -26,7 +40,7 @@ func Get(url string) ([]byte, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		log.Errorf("wrong stauts code: %d", resp.StatusCode)
-		return nil, fmt.Errorf("status code %d", resp.StatusCode)
+		return nil, &HTTPStatusError{StatusCode: resp.StatusCode}
 	}
 
 	body, err := io.ReadAll(resp.Body)
@@ -63,7 +77,7 @@ func Post(url string, data []byte) ([]byte, error) {
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		log.Errorf("wrong status code: %d", resp.StatusCode)
-		return nil, fmt.Errorf("%d: %s", resp.StatusCode, body)
+		return nil, fmt.Errorf("%w: %s", &HTTPStatusError{StatusCode: resp.StatusCode}, body)
 	}
 
 	body, err := io.ReadAll(resp.Body)

--- a/server/service/vm/displaypolicy.go
+++ b/server/service/vm/displaypolicy.go
@@ -1,0 +1,153 @@
+package vm
+
+import (
+	"NanoKVM-Server/proto"
+	"NanoKVM-Server/service/ui"
+	"fmt"
+
+	"github.com/gin-gonic/gin"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	modeAlwaysOn  = "alwaysOn"
+	modeIdleClock = "idleClock"
+	modeIdleOff   = "idleOff"
+)
+
+func (s *Service) GetLcdDisplayPolicy(c *gin.Context) {
+	var rsp proto.Response
+	screenType, err := getScreenType()
+	if err != nil {
+		rsp.ErrRsp(c, -1, "read screen type failed")
+		return
+	}
+	if screenType == screenTypeATX {
+		rsp.OkRspWithData(c, &proto.GetLcdDisplayPolicyRsp{ScreenType: string(screenType)})
+		return
+	}
+
+	policy, err := ui.GetDisplayPolicy()
+	if err == nil {
+		rsp.OkRspWithData(c, displayPolicyResponse(screenType, policy))
+		return
+	}
+	if !ui.IsNotFound(err) {
+		rsp.ErrRsp(c, -2, "get LCD display policy failed")
+		return
+	}
+
+	// Older kvm_ui exposes only the scheduled screen-off endpoint.
+	screenOff, legacyErr := ui.GetScreenOff()
+	if legacyErr != nil {
+		rsp.ErrRsp(c, -2, "get LCD display policy failed")
+		return
+	}
+	rsp.OkRspWithData(c, &proto.GetLcdDisplayPolicyRsp{
+		ScreenType: string(screenType),
+		Schedule: proto.LcdDisplaySchedule{
+			Supported:   true,
+			Enabled:     screenOff.Enabled,
+			StartMinute: screenOff.StartMinute,
+			EndMinute:   screenOff.EndMinute,
+		},
+	})
+}
+
+func (s *Service) SetLcdDisplayPolicy(c *gin.Context) {
+	var req proto.SetLcdDisplayPolicyReq
+	var rsp proto.Response
+	if err := proto.ParseFormRequest(c, &req); err != nil {
+		rsp.ErrRsp(c, -1, "invalid arguments")
+		return
+	}
+	if err := validateDisplayPolicyRequest(req); err != nil {
+		rsp.ErrRsp(c, -1, err.Error())
+		return
+	}
+	screenType, err := getScreenType()
+	if err != nil {
+		rsp.ErrRsp(c, -2, "read screen type failed")
+		return
+	}
+	if screenType != screenTypeDesk {
+		rsp.ErrRsp(c, -3, "LCD display policy is only supported on Desk")
+		return
+	}
+
+	update := ui.DisplayPolicyUpdate{Mode: req.Mode}
+	if req.Schedule != nil {
+		update.Schedule = &ui.DisplaySchedule{
+			Enabled:     *req.Schedule.Enabled,
+			StartMinute: *req.Schedule.StartMinute,
+			EndMinute:   *req.Schedule.EndMinute,
+		}
+	}
+	if err := ui.SetDisplayPolicy(update); err == nil {
+		rsp.OkRsp(c)
+		return
+	} else if !ui.IsNotFound(err) {
+		rsp.ErrRsp(c, -4, "set LCD display policy failed")
+		return
+	}
+
+	if req.Mode != nil {
+		rsp.ErrRsp(c, -4, "LCD display modes are not supported by this device")
+		return
+	}
+	if req.Schedule == nil {
+		rsp.ErrRsp(c, -1, "display policy update is empty")
+		return
+	}
+	if err := ui.SetScreenOff(ui.ScreenOff{
+		Enabled:     *req.Schedule.Enabled,
+		StartMinute: *req.Schedule.StartMinute,
+		EndMinute:   *req.Schedule.EndMinute,
+	}); err != nil {
+		rsp.ErrRsp(c, -4, "set screen-off schedule failed")
+		return
+	}
+	rsp.OkRsp(c)
+	log.Debugf("set LCD display policy using legacy screen-off endpoint: enabled=%t start=%d end=%d", *req.Schedule.Enabled, *req.Schedule.StartMinute, *req.Schedule.EndMinute)
+}
+
+func displayPolicyResponse(screenType screenType, policy *ui.DisplayPolicy) *proto.GetLcdDisplayPolicyRsp {
+	return &proto.GetLcdDisplayPolicyRsp{
+		ScreenType:         string(screenType),
+		SupportedModes:     policy.SupportedModes,
+		Mode:               policy.Mode,
+		ModeTimeoutSeconds: policy.ModeTimeoutSeconds,
+		Schedule: proto.LcdDisplaySchedule{
+			Supported:          policy.Schedule.Supported,
+			Enabled:            policy.Schedule.Enabled,
+			StartMinute:        policy.Schedule.StartMinute,
+			EndMinute:          policy.Schedule.EndMinute,
+			WakeTimeoutSeconds: policy.Schedule.WakeTimeoutSeconds,
+		},
+	}
+}
+
+func validateDisplayPolicyRequest(req proto.SetLcdDisplayPolicyReq) error {
+	if req.Mode == nil && req.Schedule == nil {
+		return fmt.Errorf("display policy update is empty")
+	}
+	if req.Mode != nil {
+		switch *req.Mode {
+		case modeAlwaysOn, modeIdleClock, modeIdleOff:
+		default:
+			return fmt.Errorf("unsupported LCD display mode %q", *req.Mode)
+		}
+	}
+	if req.Schedule != nil {
+		if req.Schedule.Enabled == nil || req.Schedule.StartMinute == nil || req.Schedule.EndMinute == nil {
+			return fmt.Errorf("schedule requires enabled, startMinute, and endMinute")
+		}
+		if *req.Schedule.StartMinute < 0 || *req.Schedule.StartMinute >= minutesPerDay || *req.Schedule.EndMinute < 0 || *req.Schedule.EndMinute >= minutesPerDay {
+			return fmt.Errorf("startMinute and endMinute must be between 0 and %d", minutesPerDay-1)
+		}
+		if *req.Schedule.Enabled && *req.Schedule.StartMinute == *req.Schedule.EndMinute {
+			return fmt.Errorf("startMinute and endMinute must differ")
+		}
+	}
+	return nil
+}

--- a/server/service/vm/displaypolicy_test.go
+++ b/server/service/vm/displaypolicy_test.go
@@ -1,0 +1,63 @@
+package vm
+
+import (
+	"NanoKVM-Server/proto"
+	"encoding/json"
+	"testing"
+)
+
+func TestValidateDisplayPolicyRequest(t *testing.T) {
+	mode := modeIdleClock
+	if err := validateDisplayPolicyRequest(proto.SetLcdDisplayPolicyReq{Mode: &mode}); err != nil {
+		t.Fatalf("valid mode rejected: %v", err)
+	}
+
+	badMode := "scheduledOff"
+	if err := validateDisplayPolicyRequest(proto.SetLcdDisplayPolicyReq{Mode: &badMode}); err == nil {
+		t.Fatal("unsupported mode accepted")
+	}
+
+	enabled := true
+	start, end := 60, 60
+	if err := validateDisplayPolicyRequest(proto.SetLcdDisplayPolicyReq{Schedule: &proto.SetLcdDisplaySchedule{
+		Enabled:     &enabled,
+		StartMinute: &start,
+		EndMinute:   &end,
+	}}); err == nil {
+		t.Fatal("equal enabled schedule endpoints accepted")
+	}
+	validEnd := 1
+	for name, schedule := range map[string]*proto.SetLcdDisplaySchedule{
+		"all fields":  {},
+		"enabled":     {StartMinute: &start, EndMinute: &validEnd},
+		"startMinute": {Enabled: &enabled, EndMinute: &validEnd},
+		"endMinute":   {Enabled: &enabled, StartMinute: &start},
+	} {
+		t.Run("missing "+name, func(t *testing.T) {
+			if err := validateDisplayPolicyRequest(proto.SetLcdDisplayPolicyReq{Schedule: schedule}); err == nil {
+				t.Fatal("incomplete schedule accepted")
+			}
+		})
+	}
+
+	disabled, zero := false, 0
+	if err := validateDisplayPolicyRequest(proto.SetLcdDisplayPolicyReq{Schedule: &proto.SetLcdDisplaySchedule{
+		Enabled: &disabled, StartMinute: &zero, EndMinute: &zero,
+	}}); err != nil {
+		t.Fatalf("explicit false and zero values rejected: %v", err)
+	}
+
+	if err := validateDisplayPolicyRequest(proto.SetLcdDisplayPolicyReq{}); err == nil {
+		t.Fatal("empty update accepted")
+	}
+}
+
+func TestValidateDisplayPolicyRequestRejectsEmptyJSONSchedule(t *testing.T) {
+	var req proto.SetLcdDisplayPolicyReq
+	if err := json.Unmarshal([]byte(`{"schedule":{}}`), &req); err != nil {
+		t.Fatalf("unmarshal request: %v", err)
+	}
+	if err := validateDisplayPolicyRequest(req); err == nil {
+		t.Fatal("empty JSON schedule accepted")
+	}
+}

--- a/web/src/api/vm.ts
+++ b/web/src/api/vm.ts
@@ -65,6 +65,26 @@ export function setLCDScreenOff(
   return http.post('/api/vm/lcd/screen-off', config);
 }
 
+export type LCDDisplayMode = 'alwaysOn' | 'idleClock' | 'idleOff';
+export type LCDDisplayPolicy = {
+  screenType: string;
+  supportedModes: LCDDisplayMode[];
+  mode?: LCDDisplayMode;
+  modeTimeoutSeconds?: Record<string, number>;
+  schedule: LCDScreenOffConfig & { wakeTimeoutSeconds?: number };
+};
+
+export function getLCDDisplayPolicy() {
+  return http.get('/api/vm/lcd/display-policy');
+}
+
+export function setLCDDisplayPolicy(update: {
+  mode?: LCDDisplayMode;
+  schedule?: Pick<LCDScreenOffConfig, 'enabled' | 'startMinute' | 'endMinute'>;
+}) {
+  return http.post('/api/vm/lcd/display-policy', update);
+}
+
 // get HDMI capture status
 export function getHdmiCapture() {
   return http.get('/api/vm/hdmi/capture');

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -390,6 +390,16 @@ const en = {
           invalidRange: 'Start and end times must be different.',
           saveFailed: 'Unable to save the scheduled screen-off settings.'
         },
+        displayPolicy: {
+          title: 'Desk screen',
+          description: 'Choose what the built-in screen shows while idle',
+          modes: {
+            alwaysOn: 'Always on',
+            idleClock: 'Show clock when idle',
+            idleOff: 'Turn off when idle'
+          },
+          saveFailed: 'Unable to save the screen display setting.'
+        },
         wifi: {
           title: 'Wi-Fi',
           description: 'Configure Wi-Fi',

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -368,6 +368,16 @@ const zh = {
           invalidRange: '开始时间和结束时间不能相同。',
           saveFailed: '无法保存定时熄屏设置。'
         },
+        displayPolicy: {
+          title: 'Desk 屏幕',
+          description: '选择内置屏幕闲置时的显示方式',
+          modes: {
+            alwaysOn: '始终显示',
+            idleClock: '闲置时显示时钟',
+            idleOff: '闲置后熄屏'
+          },
+          saveFailed: '无法保存屏幕显示设置。'
+        },
         wifi: {
           title: 'Wi-Fi',
           description: '配置 Wi-Fi 信息',

--- a/web/src/pages/desktop/menu/settings/device/display-policy.tsx
+++ b/web/src/pages/desktop/menu/settings/device/display-policy.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import { Select } from 'antd';
+import { useTranslation } from 'react-i18next';
+
+import { getLCDDisplayPolicy, setLCDDisplayPolicy, type LCDDisplayMode, type LCDDisplayPolicy } from '@/api/vm.ts';
+
+export const DisplayPolicy = () => {
+  const { t } = useTranslation();
+  const [policy, setPolicy] = useState<LCDDisplayPolicy>();
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState(false);
+
+  useEffect(() => {
+    getLCDDisplayPolicy().then((rsp) => {
+      if (rsp.code === 0 && rsp.data?.supportedModes?.length) setPolicy(rsp.data);
+    }).catch(console.error);
+  }, []);
+
+  if (!policy) return null;
+  const mode = policy.mode ?? 'alwaysOn';
+  const save = (update: Parameters<typeof setLCDDisplayPolicy>[0]) => {
+    if (saving) return;
+    setSaveError(false);
+    setSaving(true);
+    setLCDDisplayPolicy(update).then((rsp) => {
+      if (rsp.code === 0) setPolicy((current) => current && {
+        ...current,
+        ...(update.mode ? { mode: update.mode } : {}),
+        ...(update.schedule ? { schedule: { ...current.schedule, ...update.schedule } } : {})
+      });
+      else setSaveError(true);
+    }).catch((error) => {
+      console.error(error);
+      setSaveError(true);
+    }).finally(() => setSaving(false));
+  };
+
+  return <div className="space-y-3 pt-3">
+    <div className="flex items-center justify-between gap-3">
+      <div className="flex flex-col space-y-1">
+        <span>{t('settings.device.displayPolicy.title')}</span>
+        <span className="text-xs text-neutral-500">{t('settings.device.displayPolicy.description')}</span>
+      </div>
+      <Select disabled={saving} value={mode} style={{ width: 150 }} onChange={(value: LCDDisplayMode) => save({ mode: value })}
+        options={policy.supportedModes.map((value) => ({ value, label: t(`settings.device.displayPolicy.modes.${value}`) }))} />
+    </div>
+    {saveError && <div className="mx-5 text-xs text-red-500">{t('settings.device.displayPolicy.saveFailed')}</div>}
+  </div>;
+};

--- a/web/src/pages/desktop/menu/settings/device/index.tsx
+++ b/web/src/pages/desktop/menu/settings/device/index.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 
 import { Advanced } from './advanced';
 import { Datetime } from './datetime';
+import { DisplayPolicy } from './display-policy.tsx';
 import { HdmiCapture } from './hdmi-capture.tsx';
 import { HdmiPassthrough } from './hdmi-passthrough.tsx';
 import { LedStrip } from './led-strip.tsx';
@@ -34,6 +35,7 @@ export const Device = () => {
         <Divider className="opacity-50" />
 
         <Oled />
+        <DisplayPolicy />
         <ScheduledScreenOff />
         <Wifi />
         <MouseJiggler />


### PR DESCRIPTION
## Summary

This PR adds web controls for the built-in display policy on supported NanoKVM-Pro Desk devices.

Users can choose Always On, Auto Clock, or Auto Sleep. The existing daily screen-off schedule remains available and is managed alongside the selected mode.

## Changes

- Added authenticated display-policy read and update APIs covering the current mode, supported modes, mode timeouts, and the daily schedule.
- Added strict response validation so malformed or incomplete device responses are rejected instead of silently hiding the control.
- Added strict request validation for complete schedule updates, including minute bounds and enabled-schedule endpoint rules.
- Added a typed device-service bridge for reading and updating the display policy.
- Added the Display Policy control to Device settings and localized its labels, descriptions, validation errors, and save errors.
- Preserved the existing scheduled screen-off behavior, including cross-midnight schedules and rollback after failed saves.
- Kept the control conditional on device support; unsupported hardware does not expose the setting.

## Verification

- `go test ./service/vm ./service/ui`
- `pnpm run build`
- `git diff --check`
- [x] Manual hardware test: verify each display mode and mode transition
- [x] Manual hardware test: verify schedule editing, disable/enable behavior, and cross-midnight schedules

## Compatibility

The web API requires the corresponding display-policy endpoint from the device-side display service. Existing screen-off schedule clients remain supported through the existing endpoint.

## Screenshots (Hardware Testing)

<img width="494" height="214" alt="image" src="https://github.com/user-attachments/assets/3bbd31bd-a2c5-4447-ac23-af03f4aa32d7" />